### PR TITLE
fix: use sample_name_converter in read_glyhunter

### DIFF
--- a/R/glyhunter.R
+++ b/R/glyhunter.R
@@ -61,6 +61,13 @@ read_glyhunter <- function(
 ) {
   df <- suppressMessages(readr::read_csv(fp))
 
+  # Rename samples
+  if (!is.null(sample_name_converter)) {
+    samples <- setdiff(colnames(df), "glycan")
+    new_samples <- sample_name_converter(samples)
+    colnames(df) <- c("glycan", new_samples)
+  }
+
   # Prepare sample info
   samples <- setdiff(colnames(df), "glycan")
   sample_info <- .process_sample_info(sample_info, samples, glycan_type)
@@ -102,6 +109,13 @@ read_glyhunter <- function(
   sample_name_converter = NULL
 ) {
   df <- suppressMessages(readr::read_csv(fp))
+
+  # Rename samples
+  if (!is.null(sample_name_converter)) {
+    samples <- setdiff(colnames(df), "glycan")
+    new_samples <- sample_name_converter(samples)
+    colnames(df) <- c("glycan", new_samples)
+  }
 
   # Prepare sample info
   samples <- setdiff(colnames(df), "glycan")

--- a/tests/testthat/test-glyhunter.R
+++ b/tests/testthat/test-glyhunter.R
@@ -21,3 +21,15 @@ test_that("read_glyhunter works for NP preset", {
   expect_s3_class(exp$var_info$glycan_composition, "glyrepr_composition")
   expect_true(all(c("nL", "nE") %in% colnames(exp$var_info)))
 })
+
+test_that("read_glyhunter works with sample name converter", {
+  exp <- suppressMessages(read_glyhunter(
+    test_path("data/glyhunter-result.csv"),
+    glycan_type = "N",
+    sample_name_converter = function(samples) {
+      paste0("Sample_", samples)
+    }
+  ))
+
+  expect_true(all(grepl("^Sample_", colnames(exp$expr_mat))))
+})


### PR DESCRIPTION
## Summary

- Fix the bug where `sample_name_converter` was accepted as an argument but never actually applied in `read_glyhunter()`.
- Apply the converter to rename sample columns before processing sample info.
- Add test coverage to verify the converter is used.

## Test plan

- [x] Added `test_that` block for `sample_name_converter` in `test-glyhunter.R`
- [x] Run `devtools::test(filter = \"glyhunter\")` to confirm the new test passes
- [x] Run `devtools::test()` to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)