### PR TITLE
Update multisite handling in Byonic readers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyread (development version)
 
+## New features
+
+* `read_byonic_byologic()` and `read_byonic_pglycoquant()` now have a new logic to handle glycopeptides with multiple glycosites. A `multisite` parameter is added to control this. If `multisite = "expand"` (default), glycopeptides with multiple glycosites will be expanded into multiple rows, each with one glycosite. If `multisite = "drop"`, multisite glycopeptides will be dropped (#11).
+
 # glyread 0.10.0
 
 ## New features

--- a/R/aggregate-utils.R
+++ b/R/aggregate-utils.R
@@ -12,16 +12,43 @@
     "gene",
     "glycan_composition",
     "glycan_structure",
-    "gp_id",
     "proteins",
     "genes",
     "protein_sites"
   )
-  sample_names <- unique(df$sample)
-  res_df <- df %>%
+
+  group_cols <- intersect(aggr_cols, colnames(df))
+  value_df <- df %>%
     dplyr::summarise(
       value = sum(.data$value, na.rm = TRUE),
-      .by = any_of(c(aggr_cols, "sample"))
-    ) %>%
+      .by = any_of(c(group_cols, "sample"))
+    )
+
+  if ("gp_id" %in% colnames(df)) {
+    gp_id_df <- df %>%
+      dplyr::summarise(
+        gp_id = .collapse_trace_ids(.data$gp_id),
+        .by = any_of(group_cols)
+      )
+    value_df <- dplyr::left_join(value_df, gp_id_df, by = group_cols)
+  }
+
+  value_df %>%
     dplyr::mutate(value = dplyr::if_else(.data$value == 0, NA, .data$value))
+}
+
+#' Collapse trace IDs while preserving first-seen order
+#'
+#' @param x A character vector of trace IDs.
+#'
+#' @returns A semicolon-separated character scalar, or `NA_character_` if all
+#'   IDs are missing.
+#' @noRd
+.collapse_trace_ids <- function(x) {
+  x <- unique(stats::na.omit(x))
+  if (length(x) == 0) {
+    return(NA_character_)
+  }
+
+  paste(x, collapse = ";")
 }

--- a/R/aggregate-utils.R
+++ b/R/aggregate-utils.R
@@ -12,6 +12,7 @@
     "gene",
     "glycan_composition",
     "glycan_structure",
+    "gp_id",
     "proteins",
     "genes",
     "protein_sites"

--- a/R/aggregate-utils.R
+++ b/R/aggregate-utils.R
@@ -17,38 +17,10 @@
     "protein_sites"
   )
 
-  group_cols <- intersect(aggr_cols, colnames(df))
-  value_df <- df %>%
+  df %>%
     dplyr::summarise(
       value = sum(.data$value, na.rm = TRUE),
-      .by = any_of(c(group_cols, "sample"))
-    )
-
-  if ("gp_id" %in% colnames(df)) {
-    gp_id_df <- df %>%
-      dplyr::summarise(
-        gp_id = .collapse_trace_ids(.data$gp_id),
-        .by = any_of(group_cols)
-      )
-    value_df <- dplyr::left_join(value_df, gp_id_df, by = group_cols)
-  }
-
-  value_df %>%
+      .by = any_of(c(aggr_cols, "sample"))
+    ) %>%
     dplyr::mutate(value = dplyr::if_else(.data$value == 0, NA, .data$value))
-}
-
-#' Collapse trace IDs while preserving first-seen order
-#'
-#' @param x A character vector of trace IDs.
-#'
-#' @returns A semicolon-separated character scalar, or `NA_character_` if all
-#'   IDs are missing.
-#' @noRd
-.collapse_trace_ids <- function(x) {
-  x <- unique(stats::na.omit(x))
-  if (length(x) == 0) {
-    return(NA_character_)
-  }
-
-  paste(x, collapse = ";")
 }

--- a/R/byonic-byologic.R
+++ b/R/byonic-byologic.R
@@ -12,8 +12,12 @@
 #' The exported .csv file is the file you should use.
 #'
 #' @section Multisite glycopeptides:
-#' Multisite glycopeptides are supported but their `protein_site` will be set to `NA`
-#' since the exact site of glycosylation cannot be determined unambiguously.
+#' Some glycopeptides can have more than one glycosylation site.
+#' In this case, it will be expanded into multiple rows with the same quantification value
+#' but different `protein_site` and `glycan_composition`.
+#' This is generally fine if downstream analyses are done at the glycoform level.
+#' A `gp_id` column is also added to uniquely identify each glycopeptide before row expansion,
+#' so that the multiple rows can be mapped back to the original glycopeptide if needed.
 #'
 #' @inheritSection read_pglyco3_pglycoquant Sample information
 #' @inheritSection read_pglyco3_pglycoquant Aggregation
@@ -26,6 +30,7 @@
 #' - `protein_site`: integer, site of glycosylation on protein
 #' - `gene`: character, gene name (symbol)
 #' - `glycan_composition`: [glyrepr::glycan_composition()], glycan compositions.
+#' - `gp_id`: character, glycopeptide ID before multisite row expansion.
 #'
 #' @inheritParams read_pglyco3_pglycoquant
 #' @param orgdb name of the OrgDb package to use for UniProt to gene symbol conversion.
@@ -91,11 +96,9 @@ read_byonic_byologic <- function(
   )
 
   # Apply type conversion to the cleaned data
-  df_typed <- df_clean |>
+  df_clean |>
     dplyr::select(dplyr::any_of(names(expected_cols$cols))) |>
     readr::type_convert(col_types = expected_cols)
-
-  return(df_typed)
 }
 
 .tidy_byonic_byologic <- function(df, orgdb) {
@@ -113,6 +116,10 @@ read_byonic_byologic <- function(
 }
 
 .handle_multisite_byologic <- function(df) {
+  if (!"row_number" %in% colnames(df)) {
+    df <- dplyr::mutate(df, row_number = as.character(dplyr::row_number()))
+  }
+
   # Identify multisite glycopeptides (those with commas in glycans column)
   is_multisite <- stringr::str_detect(df$glycans, stringr::fixed(","))
   n_multisite <- sum(is_multisite)
@@ -120,13 +127,23 @@ read_byonic_byologic <- function(
   if (n_multisite > 0) {
     perc_multisite <- round(n_multisite / nrow(df) * 100, 1)
     cli::cli_alert_info(
-      "Found {.val {n_multisite}} of {.val {nrow(df)}} ({.val {perc_multisite}}%) multisite glycopeptides. Setting protein_site to NA for these entries."
+      "Found {.val {n_multisite}} of {.val {nrow(df)}} ({.val {perc_multisite}}%) multisite glycopeptides. Expanding these entries to site-specific rows."
     )
   }
 
-  # Keep all rows but mark multisite ones for special handling
-  df$is_multisite <- is_multisite
-  df
+  df %>%
+    dplyr::mutate(
+      gp_source = stringr::str_split_i(.data$row_number, stringr::fixed("."), 1L),
+      gp_id = paste0("BGP", dplyr::dense_rank(.data$gp_source)),
+      glycan_composition = purrr::map(.data$glycans, .split_byologic_glycans),
+      peptide_site = purrr::map(.data$mod_summary, .extract_byologic_glycosites),
+      n_glycans = purrr::map_int(.data$glycan_composition, length),
+      n_sites = purrr::map_int(.data$peptide_site, length)
+    ) %>%
+    .check_byologic_glycosite_pairing() %>%
+    tidyr::unnest_longer(c("glycan_composition", "peptide_site")) %>%
+    dplyr::mutate(peptide_site = as.integer(.data$peptide_site)) %>%
+    dplyr::select(-all_of(c("gp_source", "n_glycans", "n_sites")))
 }
 
 # Collapse hierarchical search-result rows to peptide–sample abundances
@@ -165,7 +182,13 @@ read_byonic_byologic <- function(
 }
 
 .refine_byonic_byologic_columns <- function(df) {
+  expanded_cols <- c("gp_id", "glycan_composition", "peptide_site")
+  if (!all(expanded_cols %in% colnames(df))) {
+    df <- .handle_multisite_byologic(df)
+  }
+
   selected_cols <- c(
+    "gp_id",
     "peptide",
     "peptide_site",
     "protein",
@@ -183,33 +206,8 @@ read_byonic_byologic <- function(
       peptide = stringr::str_split_i(.data$sequence, stringr::fixed("."), 2L),
       # EHEGAIYPDnTTDFQR -> EHEGAIYPDNTTDFQR (n -> N)
       peptide = stringr::str_to_upper(.data$peptide),
-      # Fuc -> dHex
-      glycan_composition = stringr::str_replace(.data$glycans, "Fuc", "dHex"),
-      # Add peptide_site
-      peptide_site = stringr::str_extract(
-        .data$mod_summary,
-        "N(\\d+)\\(NGlycan",
-        group = 1
-      ),
-      peptide_site = as.integer(.data$peptide_site)
-    )
-
-  # Add protein_site - set to NA for multisite glycopeptides (if is_multisite column exists)
-  if ("is_multisite" %in% colnames(result)) {
-    result <- dplyr::mutate(
-      result,
-      protein_site = dplyr::if_else(
-        .data$is_multisite,
-        NA_integer_,
-        as.integer(.data$start_aa + .data$peptide_site - 1L)
-      )
-    )
-  } else {
-    result <- dplyr::mutate(
-      result,
       protein_site = as.integer(.data$start_aa + .data$peptide_site - 1L)
     )
-  }
 
   result %>%
     dplyr::rename(all_of(c(
@@ -217,4 +215,61 @@ read_byonic_byologic <- function(
       value = "xic_area_summed"
     ))) %>%
     dplyr::select(all_of(selected_cols))
+}
+
+#' Split Byologic glycan compositions by glycosylation site
+#'
+#' @param glycans A single Byologic glycan composition string.
+#'
+#' @returns A character vector with one glycan composition per site.
+#' @noRd
+.split_byologic_glycans <- function(glycans) {
+  if (is.na(glycans)) {
+    return(NA_character_)
+  }
+
+  glycans %>%
+    stringr::str_replace_all("Fuc", "dHex") %>%
+    stringr::str_split(stringr::fixed(","), simplify = FALSE) %>%
+    purrr::pluck(1) %>%
+    stringr::str_trim()
+}
+
+#' Extract Byologic glycosylation sites
+#'
+#' @param mod_summary A single Byologic modification summary string.
+#'
+#' @returns An integer vector with one peptide site per glycan.
+#' @noRd
+.extract_byologic_glycosites <- function(mod_summary) {
+  if (is.na(mod_summary)) {
+    return(NA_integer_)
+  }
+
+  matches <- stringr::str_match_all(
+    mod_summary,
+    "N(\\d+)\\(NGlycan"
+  )[[1]]
+
+  as.integer(matches[, 2])
+}
+
+#' Check glycan-site pairing in Byologic rows
+#'
+#' @param df A collapsed Byologic tibble with list columns for glycan
+#'   compositions and peptide sites.
+#'
+#' @returns The input tibble, invisibly checked.
+#' @noRd
+.check_byologic_glycosite_pairing <- function(df) {
+  invalid_rows <- df$row_number[df$n_glycans != df$n_sites]
+  if (length(invalid_rows) > 0) {
+    rlang::abort(c(
+      "Cannot pair Byologic glycan compositions with glycosylation sites.",
+      i = "The number of comma-separated glycans must match the number of NGlycan sites in `mod_summary`.",
+      x = glue::glue("Problematic rows: {toString(invalid_rows)}")
+    ))
+  }
+
+  df
 }

--- a/R/byonic-byologic.R
+++ b/R/byonic-byologic.R
@@ -141,12 +141,19 @@ read_byonic_byologic <- function(
     dplyr::mutate(
       gp_source = stringr::str_split_i(.data$row_number, stringr::fixed("."), 1L),
       gp_id = paste0("BGP", dplyr::dense_rank(.data$gp_source)),
-      glycan_composition = purrr::map(.data$glycans, .split_byologic_glycans),
+      glycan_composition = purrr::map(
+        .data$glycans,
+        .split_byonic_glycan_compositions
+      ),
       peptide_site = purrr::map(.data$mod_summary, .extract_byologic_glycosites),
       n_glycans = purrr::map_int(.data$glycan_composition, length),
       n_sites = purrr::map_int(.data$peptide_site, length)
     ) %>%
-    .check_byologic_glycosite_pairing() %>%
+    .check_byonic_glycan_site_pairing(
+      source = "Byologic",
+      site_column = "mod_summary",
+      row_id = dplyr::pull(., "row_number")
+    ) %>%
     tidyr::unnest_longer(c("glycan_composition", "peptide_site")) %>%
     dplyr::mutate(peptide_site = as.integer(.data$peptide_site)) %>%
     dplyr::select(-all_of(c("gp_source", "n_glycans", "n_sites")))
@@ -225,24 +232,6 @@ read_byonic_byologic <- function(
     dplyr::select(all_of(selected_cols))
 }
 
-#' Split Byologic glycan compositions by glycosylation site
-#'
-#' @param glycans A single Byologic glycan composition string.
-#'
-#' @returns A character vector with one glycan composition per site.
-#' @noRd
-.split_byologic_glycans <- function(glycans) {
-  if (is.na(glycans)) {
-    return(NA_character_)
-  }
-
-  glycans %>%
-    stringr::str_replace_all("Fuc", "dHex") %>%
-    stringr::str_split(stringr::fixed(","), simplify = FALSE) %>%
-    purrr::pluck(1) %>%
-    stringr::str_trim()
-}
-
 #' Extract Byologic glycosylation sites
 #'
 #' @param mod_summary A single Byologic modification summary string.
@@ -260,24 +249,4 @@ read_byonic_byologic <- function(
   )[[1]]
 
   as.integer(matches[, 2])
-}
-
-#' Check glycan-site pairing in Byologic rows
-#'
-#' @param df A collapsed Byologic tibble with list columns for glycan
-#'   compositions and peptide sites.
-#'
-#' @returns The input tibble, invisibly checked.
-#' @noRd
-.check_byologic_glycosite_pairing <- function(df) {
-  invalid_rows <- df$row_number[df$n_glycans != df$n_sites]
-  if (length(invalid_rows) > 0) {
-    rlang::abort(c(
-      "Cannot pair Byologic glycan compositions with glycosylation sites.",
-      i = "The number of comma-separated glycans must match the number of NGlycan sites in `mod_summary`.",
-      x = glue::glue("Problematic rows: {toString(invalid_rows)}")
-    ))
-  }
-
-  df
 }

--- a/R/byonic-byologic.R
+++ b/R/byonic-byologic.R
@@ -137,7 +137,7 @@ read_byonic_byologic <- function(
     )
   }
 
-  df %>%
+  expanded_df <- df %>%
     dplyr::mutate(
       gp_source = stringr::str_split_i(.data$row_number, stringr::fixed("."), 1L),
       gp_id = paste0("BGP", dplyr::dense_rank(.data$gp_source)),
@@ -148,11 +148,13 @@ read_byonic_byologic <- function(
       peptide_site = purrr::map(.data$mod_summary, .extract_byologic_glycosites),
       n_glycans = purrr::map_int(.data$glycan_composition, length),
       n_sites = purrr::map_int(.data$peptide_site, length)
-    ) %>%
+    )
+
+  expanded_df %>%
     .check_byonic_glycan_site_pairing(
       source = "Byologic",
       site_column = "mod_summary",
-      row_id = dplyr::pull(., "row_number")
+      row_id = expanded_df$row_number
     ) %>%
     tidyr::unnest_longer(c("glycan_composition", "peptide_site")) %>%
     dplyr::mutate(peptide_site = as.integer(.data$peptide_site)) %>%

--- a/R/byonic-byologic.R
+++ b/R/byonic-byologic.R
@@ -16,8 +16,6 @@
 #' In this case, it will be expanded into multiple rows with the same quantification value
 #' but different `protein_site` and `glycan_composition`.
 #' This is generally fine if downstream analyses are done at the glycoform level.
-#' A `gp_id` column is also added to uniquely identify each glycopeptide before row expansion,
-#' so that the multiple rows can be mapped back to the original glycopeptide if needed.
 #'
 #' @inheritSection read_pglyco3_pglycoquant Sample information
 #' @inheritSection read_pglyco3_pglycoquant Aggregation
@@ -30,7 +28,6 @@
 #' - `protein_site`: integer, site of glycosylation on protein
 #' - `gene`: character, gene name (symbol)
 #' - `glycan_composition`: [glyrepr::glycan_composition()], glycan compositions.
-#' - `gp_id`: character, glycopeptide ID before multisite row expansion.
 #'
 #' @inheritParams read_pglyco3_pglycoquant
 #' @param orgdb name of the OrgDb package to use for UniProt to gene symbol conversion.
@@ -114,8 +111,7 @@ read_byonic_byologic <- function(
 #'
 #' Byologic reports multisite glycopeptides as one row with comma-separated
 #' glycan compositions and semicolon-separated NGlycan entries in `mod_summary`.
-#' This helper expands those rows to one row per glycosylation site while
-#' preserving a shared `gp_id`.
+#' This helper expands those rows to one row per glycosylation site.
 #'
 #' @param df A collapsed Byologic tibble.
 #'
@@ -139,8 +135,6 @@ read_byonic_byologic <- function(
 
   expanded_df <- df %>%
     dplyr::mutate(
-      gp_source = stringr::str_split_i(.data$row_number, stringr::fixed("."), 1L),
-      gp_id = paste0("BGP", dplyr::dense_rank(.data$gp_source)),
       glycan_composition = purrr::map(
         .data$glycans,
         .split_byonic_glycan_compositions
@@ -158,7 +152,7 @@ read_byonic_byologic <- function(
     ) %>%
     tidyr::unnest_longer(c("glycan_composition", "peptide_site")) %>%
     dplyr::mutate(peptide_site = as.integer(.data$peptide_site)) %>%
-    dplyr::select(-all_of(c("gp_source", "n_glycans", "n_sites")))
+    dplyr::select(-all_of(c("n_glycans", "n_sites")))
 }
 
 # Collapse hierarchical search-result rows to peptide–sample abundances
@@ -205,7 +199,6 @@ read_byonic_byologic <- function(
 #' @noRd
 .standardize_byologic_columns <- function(df) {
   selected_cols <- c(
-    "gp_id",
     "peptide",
     "peptide_site",
     "protein",

--- a/R/byonic-byologic.R
+++ b/R/byonic-byologic.R
@@ -13,9 +13,9 @@
 #'
 #' @section Multisite glycopeptides:
 #' Some glycopeptides can have more than one glycosylation site.
-#' In this case, it will be expanded into multiple rows with the same quantification value
+#' By default, they are expanded into multiple rows with the same quantification value
 #' but different `protein_site` and `glycan_composition`.
-#' This is generally fine if downstream analyses are done at the glycoform level.
+#' Set `multisite = "drop"` to remove multisite glycopeptides instead.
 #'
 #' @inheritSection read_pglyco3_pglycoquant Sample information
 #' @inheritSection read_pglyco3_pglycoquant Aggregation
@@ -32,6 +32,9 @@
 #' @inheritParams read_pglyco3_pglycoquant
 #' @param orgdb name of the OrgDb package to use for UniProt to gene symbol conversion.
 #'  Default is "org.Hs.eg.db".
+#' @param multisite How to handle multisite glycopeptides.
+#'   - "expand" (default) expands each multisite glycopeptide into site-specific rows.
+#'   - "drop" removes multisite glycopeptides.
 #'
 #' @returns An [glyexp::experiment()] object.
 #' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()]
@@ -42,7 +45,8 @@ read_byonic_byologic <- function(
   quant_method = "label-free",
   glycan_type = "N",
   sample_name_converter = NULL,
-  orgdb = "org.Hs.eg.db"
+  orgdb = "org.Hs.eg.db",
+  multisite = "expand"
 ) {
   # ----- Check arguments -----
   .validate_read_args(
@@ -54,13 +58,14 @@ read_byonic_byologic <- function(
     sample_name_converter = sample_name_converter,
     orgdb = orgdb
   )
+  checkmate::assert_choice(multisite, c("expand", "drop"))
 
   # ----- Read data -----
   # Keep all PSM-level columns for variable info
   if (quant_method == "label-free") {
     cli::cli_progress_step("Reading data")
     df <- .read_byonic_byologic_df(fp)
-    tidy_df <- .tidy_byonic_byologic(df, orgdb)
+    tidy_df <- .tidy_byonic_byologic(df, orgdb, multisite)
     exp <- .read_template(
       tidy_df,
       sample_info,
@@ -98,13 +103,26 @@ read_byonic_byologic <- function(
     readr::type_convert(col_types = expected_cols)
 }
 
-.tidy_byonic_byologic <- function(df, orgdb) {
+.tidy_byonic_byologic <- function(df, orgdb, multisite = "expand") {
   df %>%
     dplyr::filter(!is.na(.data$glycans)) %>%
     .collapse_byologic_rows() %>%
-    .expand_byologic_multisite_rows() %>%
+    .handle_byologic_multisite_rows(multisite) %>%
     .standardize_byologic_columns() %>%
     .add_gene_symbols(orgdb)
+}
+
+.handle_byologic_multisite_rows <- function(df, multisite) {
+  switch(
+    multisite,
+    expand = .expand_byologic_multisite_rows(df),
+    drop = df %>%
+      .drop_byonic_multisite_rows(
+        glycan_col = "glycans",
+        source = "Byologic"
+      ) %>%
+      .expand_byologic_multisite_rows()
+  )
 }
 
 #' Expand Byologic multisite glycopeptides

--- a/R/byonic-byologic.R
+++ b/R/byonic-byologic.R
@@ -103,19 +103,25 @@ read_byonic_byologic <- function(
 
 .tidy_byonic_byologic <- function(df, orgdb) {
   df %>%
-    .filter_byonic_byologic_rows() %>%
-    .refine_byonic_byologic_columns() %>%
+    dplyr::filter(!is.na(.data$glycans)) %>%
+    .collapse_byologic_rows() %>%
+    .expand_byologic_multisite_rows() %>%
+    .standardize_byologic_columns() %>%
     .add_gene_symbols(orgdb)
 }
 
-.filter_byonic_byologic_rows <- function(df) {
-  df %>%
-    dplyr::filter(!is.na(.data$glycans)) %>%
-    .collapse_byologic_rows() %>%
-    .handle_multisite_byologic()
-}
-
-.handle_multisite_byologic <- function(df) {
+#' Expand Byologic multisite glycopeptides
+#'
+#' Byologic reports multisite glycopeptides as one row with comma-separated
+#' glycan compositions and semicolon-separated NGlycan entries in `mod_summary`.
+#' This helper expands those rows to one row per glycosylation site while
+#' preserving a shared `gp_id`.
+#'
+#' @param df A collapsed Byologic tibble.
+#'
+#' @returns A tibble with one row per glycosylation site.
+#' @noRd
+.expand_byologic_multisite_rows <- function(df) {
   if (!"row_number" %in% colnames(df)) {
     df <- dplyr::mutate(df, row_number = as.character(dplyr::row_number()))
   }
@@ -181,12 +187,14 @@ read_byonic_byologic <- function(
     dplyr::select(-all_of(c("depth", "lvl1", "has_lvl2")))
 }
 
-.refine_byonic_byologic_columns <- function(df) {
-  expanded_cols <- c("gp_id", "glycan_composition", "peptide_site")
-  if (!all(expanded_cols %in% colnames(df))) {
-    df <- .handle_multisite_byologic(df)
-  }
-
+#' Standardize expanded Byologic columns
+#'
+#' @param df A Byologic tibble after multisite row expansion.
+#'
+#' @returns A long-format tibble with standard glycopeptide variable columns,
+#'   `sample`, and `value`.
+#' @noRd
+.standardize_byologic_columns <- function(df) {
   selected_cols <- c(
     "gp_id",
     "peptide",

--- a/R/byonic-byologic.R
+++ b/R/byonic-byologic.R
@@ -157,7 +157,10 @@ read_byonic_byologic <- function(
         .data$glycans,
         .split_byonic_glycan_compositions
       ),
-      peptide_site = purrr::map(.data$mod_summary, .extract_byologic_glycosites),
+      peptide_site = purrr::map(
+        .data$mod_summary,
+        .extract_byologic_glycosites
+      ),
       n_glycans = purrr::map_int(.data$glycan_composition, length),
       n_sites = purrr::map_int(.data$peptide_site, length)
     )

--- a/R/byonic-pglycoquant.R
+++ b/R/byonic-pglycoquant.R
@@ -84,7 +84,7 @@ read_byonic_pglycoquant <- function(
 .tidy_byonic_pglycoquant <- function(df, orgdb) {
   df %>%
     .expand_byonic_pglycoquant_multisite_rows() %>%
-    .refine_byonic_pglycoquant_columns() %>%
+    .standardize_byonic_pglycoquant_columns() %>%
     .add_gene_symbols(orgdb) %>%
     .pivot_longer_pglycoquant()
 }
@@ -141,7 +141,7 @@ read_byonic_pglycoquant <- function(
       gp_id = paste0("BPGQ", dplyr::dense_rank(.data$gp_key)),
       glycan_composition = purrr::map(
         .data$Composition,
-        .split_byonic_pglycoquant_glycans
+        .split_byonic_glycan_compositions
       ),
       peptide_site = purrr::map(
         .data$Peptide,
@@ -151,7 +151,10 @@ read_byonic_pglycoquant <- function(
       n_glycans = purrr::map_int(.data$glycan_composition, length),
       n_sites = purrr::map_int(.data$peptide_site, length)
     ) %>%
-    .check_byonic_pglycoquant_glycosite_pairing() %>%
+    .check_byonic_glycan_site_pairing(
+      source = "Byonic-pGlycoQuant",
+      site_column = "Peptide"
+    ) %>%
     tidyr::unnest_longer(c("glycan_composition", "peptide_site")) %>%
     dplyr::mutate(
       peptide_site = as.integer(.data$peptide_site),
@@ -162,7 +165,14 @@ read_byonic_pglycoquant <- function(
     dplyr::select(-all_of(c("gp_key", "first_peptide_site", "n_glycans", "n_sites")))
 }
 
-.refine_byonic_pglycoquant_columns <- function(df) {
+#' Standardize expanded Byonic-pGlycoQuant columns
+#'
+#' @param df A Byonic-pGlycoQuant tibble after multisite row expansion.
+#'
+#' @returns A wide-format tibble with standard glycopeptide variable columns
+#'   and pGlycoQuant intensity columns.
+#' @noRd
+.standardize_byonic_pglycoquant_columns <- function(df) {
   var_cols <- c(
     "gp_id",
     "peptide",
@@ -171,43 +181,14 @@ read_byonic_pglycoquant <- function(
     "protein_site",
     "glycan_composition"
   )
+
   df %>%
-    .convert_byonic_columns() %>%
-    dplyr::select(all_of(var_cols), tidyselect::starts_with("Intensity"))
-}
-
-.convert_byonic_columns <- function(df) {
-  expanded_cols <- c("gp_id", "glycan_composition", "peptide_site", "protein_site")
-  if (!all(expanded_cols %in% colnames(df))) {
-    df <- .expand_byonic_pglycoquant_multisite_rows(df)
-  }
-
-  result <- df %>%
     dplyr::mutate(
       peptide = .clean_byonic_pglycoquant_peptide(.data$Peptide),
       # >sp|P19652|A1AG2_HUMAN -> P19652, >sp|P08185-1|CBG_HUMAN -> P08185-1
       protein = .extract_uniprot_accession(.data$`Protein Name`)
-    )
-
-  result
-}
-
-#' Split Byonic-pGlycoQuant glycan compositions by site
-#'
-#' @param glycans A single Byonic-pGlycoQuant glycan composition string.
-#'
-#' @returns A character vector with one glycan composition per site.
-#' @noRd
-.split_byonic_pglycoquant_glycans <- function(glycans) {
-  if (is.na(glycans)) {
-    return(NA_character_)
-  }
-
-  glycans %>%
-    stringr::str_replace_all("Fuc", "dHex") %>%
-    stringr::str_split(stringr::fixed(","), simplify = FALSE) %>%
-    purrr::pluck(1) %>%
-    stringr::str_trim()
+    ) %>%
+    dplyr::select(all_of(var_cols), tidyselect::starts_with("Intensity"))
 }
 
 #' Extract glycosylated peptide sites from a Byonic peptide
@@ -259,24 +240,4 @@ read_byonic_pglycoquant <- function(
 #' @noRd
 .extract_byonic_pglycoquant_peptide_core <- function(peptide) {
   stringr::str_sub(peptide, 3L, -3L)
-}
-
-#' Check glycan-site pairing in Byonic-pGlycoQuant rows
-#'
-#' @param df A Byonic-pGlycoQuant tibble with list columns for glycan
-#'   compositions and peptide sites.
-#'
-#' @returns The input tibble, invisibly checked.
-#' @noRd
-.check_byonic_pglycoquant_glycosite_pairing <- function(df) {
-  invalid_rows <- which(df$n_glycans != df$n_sites)
-  if (length(invalid_rows) > 0) {
-    rlang::abort(c(
-      "Cannot pair Byonic-pGlycoQuant glycan compositions with glycosylation sites.",
-      i = "The number of comma-separated glycans must match the number of glycosylated N sites in `Peptide`.",
-      x = glue::glue("Problematic rows: {toString(invalid_rows)}")
-    ))
-  }
-
-  df
 }

--- a/R/byonic-pglycoquant.R
+++ b/R/byonic-pglycoquant.R
@@ -13,9 +13,9 @@
 #'
 #' @section Multisite glycopeptides:
 #' Some glycopeptides can have more than one glycosylation site.
-#' In this case, it will be expanded into multiple rows with the same quantification value
+#' By default, they are expanded into multiple rows with the same quantification value
 #' but different `protein_site` and `glycan_composition`.
-#' This is generally fine if downstream analyses are done at the glycoform level.
+#' Set `multisite = "drop"` to remove multisite glycopeptides instead.
 #'
 #' @inheritSection read_pglyco3_pglycoquant Sample information
 #' @inheritSection read_pglyco3_pglycoquant Aggregation
@@ -31,8 +31,7 @@
 #' - `glycan_structure`: [glyrepr::glycan_structure()], glycan structures (if `parse_structure = TRUE`).
 #'
 #' @inheritParams read_pglyco3_pglycoquant
-#' @param orgdb name of the OrgDb package to use for UniProt to gene symbol conversion.
-#'  Default is "org.Hs.eg.db".
+#' @inheritParams read_byonic_byologic
 #'
 #' @returns An [glyexp::experiment()] object.
 #' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()]
@@ -44,7 +43,8 @@ read_byonic_pglycoquant <- function(
   glycan_type = "N",
   sample_name_converter = NULL,
   orgdb = "org.Hs.eg.db",
-  parse_structure = TRUE
+  parse_structure = TRUE,
+  multisite = "expand"
 ) {
   # ----- Check arguments -----
   .validate_read_args(
@@ -56,13 +56,14 @@ read_byonic_pglycoquant <- function(
     sample_name_converter = sample_name_converter,
     orgdb = orgdb
   )
+  checkmate::assert_choice(multisite, c("expand", "drop"))
 
   # ----- Read data -----
   # Keep all PSM-level columns for variable info
   if (quant_method == "label-free") {
     cli::cli_progress_step("Reading data")
     df <- .read_byonic_df(fp)
-    tidy_df <- .tidy_byonic_pglycoquant(df, orgdb)
+    tidy_df <- .tidy_byonic_pglycoquant(df, orgdb, multisite)
     exp <- .read_template(
       tidy_df,
       sample_info,
@@ -78,12 +79,25 @@ read_byonic_pglycoquant <- function(
   exp
 }
 
-.tidy_byonic_pglycoquant <- function(df, orgdb) {
+.tidy_byonic_pglycoquant <- function(df, orgdb, multisite = "expand") {
   df %>%
-    .expand_byonic_pglycoquant_multisite_rows() %>%
+    .handle_byonic_pglycoquant_multisite_rows(multisite) %>%
     .standardize_byonic_pglycoquant_columns() %>%
     .add_gene_symbols(orgdb) %>%
     .pivot_longer_pglycoquant()
+}
+
+.handle_byonic_pglycoquant_multisite_rows <- function(df, multisite) {
+  switch(
+    multisite,
+    expand = .expand_byonic_pglycoquant_multisite_rows(df),
+    drop = df %>%
+      .drop_byonic_multisite_rows(
+        glycan_col = "Composition",
+        source = "Byonic-pGlycoQuant"
+      ) %>%
+      .expand_byonic_pglycoquant_multisite_rows()
+  )
 }
 
 .read_byonic_df <- function(fp) {

--- a/R/byonic-pglycoquant.R
+++ b/R/byonic-pglycoquant.R
@@ -16,8 +16,6 @@
 #' In this case, it will be expanded into multiple rows with the same quantification value
 #' but different `protein_site` and `glycan_composition`.
 #' This is generally fine if downstream analyses are done at the glycoform level.
-#' A `gp_id` column is also added to uniquely identify each glycopeptide before row expansion,
-#' so that the multiple rows can be mapped back to the original glycopeptide if needed.
 #'
 #' @inheritSection read_pglyco3_pglycoquant Sample information
 #' @inheritSection read_pglyco3_pglycoquant Aggregation
@@ -31,7 +29,6 @@
 #' - `gene`: character, gene name (symbol)
 #' - `glycan_composition`: [glyrepr::glycan_composition()], glycan compositions.
 #' - `glycan_structure`: [glyrepr::glycan_structure()], glycan structures (if `parse_structure = TRUE`).
-#' - `gp_id`: character, glycopeptide ID before multisite row expansion.
 #'
 #' @inheritParams read_pglyco3_pglycoquant
 #' @param orgdb name of the OrgDb package to use for UniProt to gene symbol conversion.
@@ -110,8 +107,7 @@ read_byonic_pglycoquant <- function(
 #'
 #' pGlycoQuant reports Byonic multisite glycopeptides as one row with
 #' comma-separated glycan compositions and multiple modified N residues in
-#' `Peptide`. This helper expands those rows to one row per glycosylation site
-#' while preserving a shared `gp_id`.
+#' `Peptide`. This helper expands those rows to one row per glycosylation site.
 #'
 #' @param df A Byonic-pGlycoQuant tibble.
 #'
@@ -131,14 +127,6 @@ read_byonic_pglycoquant <- function(
 
   df %>%
     dplyr::mutate(
-      gp_key = paste(
-        .data$Peptide,
-        .data$`Protein Name`,
-        .data$Position,
-        .data$Composition,
-        sep = "\r"
-      ),
-      gp_id = paste0("BPGQ", dplyr::dense_rank(.data$gp_key)),
       glycan_composition = purrr::map(
         .data$Composition,
         .split_byonic_glycan_compositions
@@ -162,7 +150,7 @@ read_byonic_pglycoquant <- function(
         .data$Position + .data$peptide_site - .data$first_peptide_site
       )
     ) %>%
-    dplyr::select(-all_of(c("gp_key", "first_peptide_site", "n_glycans", "n_sites")))
+    dplyr::select(-all_of(c("first_peptide_site", "n_glycans", "n_sites")))
 }
 
 #' Standardize expanded Byonic-pGlycoQuant columns
@@ -174,7 +162,6 @@ read_byonic_pglycoquant <- function(
 #' @noRd
 .standardize_byonic_pglycoquant_columns <- function(df) {
   var_cols <- c(
-    "gp_id",
     "peptide",
     "peptide_site",
     "protein",

--- a/R/byonic-pglycoquant.R
+++ b/R/byonic-pglycoquant.R
@@ -12,8 +12,12 @@
 #' the manual: [pGlycoQuant](https://github.com/Power-Quant/pGlycoQuant/blob/main/Manual%20for%20pGlycoQuant_v202211.pdf).
 #'
 #' @section Multisite glycopeptides:
-#' Multisite glycopeptides are supported but their `protein_site` will be set to `NA`
-#' since the exact site of glycosylation cannot be determined unambiguously.
+#' Some glycopeptides can have more than one glycosylation site.
+#' In this case, it will be expanded into multiple rows with the same quantification value
+#' but different `protein_site` and `glycan_composition`.
+#' This is generally fine if downstream analyses are done at the glycoform level.
+#' A `gp_id` column is also added to uniquely identify each glycopeptide before row expansion,
+#' so that the multiple rows can be mapped back to the original glycopeptide if needed.
 #'
 #' @inheritSection read_pglyco3_pglycoquant Sample information
 #' @inheritSection read_pglyco3_pglycoquant Aggregation
@@ -27,6 +31,7 @@
 #' - `gene`: character, gene name (symbol)
 #' - `glycan_composition`: [glyrepr::glycan_composition()], glycan compositions.
 #' - `glycan_structure`: [glyrepr::glycan_structure()], glycan structures (if `parse_structure = TRUE`).
+#' - `gp_id`: character, glycopeptide ID before multisite row expansion.
 #'
 #' @inheritParams read_pglyco3_pglycoquant
 #' @param orgdb name of the OrgDb package to use for UniProt to gene symbol conversion.
@@ -78,7 +83,7 @@ read_byonic_pglycoquant <- function(
 
 .tidy_byonic_pglycoquant <- function(df, orgdb) {
   df %>%
-    .handle_multisite_byonic() %>%
+    .expand_byonic_pglycoquant_multisite_rows() %>%
     .refine_byonic_pglycoquant_columns() %>%
     .add_gene_symbols(orgdb) %>%
     .pivot_longer_pglycoquant()
@@ -101,7 +106,18 @@ read_byonic_pglycoquant <- function(
   )
 }
 
-.handle_multisite_byonic <- function(df) {
+#' Expand Byonic-pGlycoQuant multisite glycopeptides
+#'
+#' pGlycoQuant reports Byonic multisite glycopeptides as one row with
+#' comma-separated glycan compositions and multiple modified N residues in
+#' `Peptide`. This helper expands those rows to one row per glycosylation site
+#' while preserving a shared `gp_id`.
+#'
+#' @param df A Byonic-pGlycoQuant tibble.
+#'
+#' @returns A tibble with one row per glycosylation site.
+#' @noRd
+.expand_byonic_pglycoquant_multisite_rows <- function(df) {
   # Identify multisite glycopeptides (those with commas in Composition column)
   is_multisite <- stringr::str_detect(df$Composition, stringr::fixed(","))
   n_multisite <- sum(is_multisite)
@@ -109,17 +125,46 @@ read_byonic_pglycoquant <- function(
   if (n_multisite > 0) {
     perc_multisite <- round(n_multisite / nrow(df) * 100, 1)
     cli::cli_alert_info(
-      "Found {.val {n_multisite}} of {.val {nrow(df)}} ({.val {perc_multisite}}%) multisite PSMs. Setting protein_site to NA for these entries."
+      "Found {.val {n_multisite}} of {.val {nrow(df)}} ({.val {perc_multisite}}%) multisite PSMs. Expanding these entries to site-specific rows."
     )
   }
 
-  # Keep all rows but mark multisite ones for special handling
-  df$is_multisite <- is_multisite
-  df
+  df %>%
+    dplyr::mutate(
+      gp_key = paste(
+        .data$Peptide,
+        .data$`Protein Name`,
+        .data$Position,
+        .data$Composition,
+        sep = "\r"
+      ),
+      gp_id = paste0("BPGQ", dplyr::dense_rank(.data$gp_key)),
+      glycan_composition = purrr::map(
+        .data$Composition,
+        .split_byonic_pglycoquant_glycans
+      ),
+      peptide_site = purrr::map(
+        .data$Peptide,
+        .extract_byonic_pglycoquant_glycosites
+      ),
+      first_peptide_site = purrr::map_int(.data$peptide_site, min),
+      n_glycans = purrr::map_int(.data$glycan_composition, length),
+      n_sites = purrr::map_int(.data$peptide_site, length)
+    ) %>%
+    .check_byonic_pglycoquant_glycosite_pairing() %>%
+    tidyr::unnest_longer(c("glycan_composition", "peptide_site")) %>%
+    dplyr::mutate(
+      peptide_site = as.integer(.data$peptide_site),
+      protein_site = as.integer(
+        .data$Position + .data$peptide_site - .data$first_peptide_site
+      )
+    ) %>%
+    dplyr::select(-all_of(c("gp_key", "first_peptide_site", "n_glycans", "n_sites")))
 }
 
 .refine_byonic_pglycoquant_columns <- function(df) {
   var_cols <- c(
+    "gp_id",
     "peptide",
     "peptide_site",
     "protein",
@@ -132,45 +177,106 @@ read_byonic_pglycoquant <- function(
 }
 
 .convert_byonic_columns <- function(df) {
-  result <- df %>%
-    dplyr::rename(
-      peptide = "Peptide",
-      protein = "Protein Name",
-      protein_site = "Position",
-      glycan_composition = "Composition"
-    ) %>%
-    dplyr::mutate(
-      # K.N[+203.07937]GTR.G -> K.nGTR.G (mark glycosylated N)
-      peptide = stringr::str_replace(.data$peptide, "N\\[.+?\\]", "n"),
-      # K.nGTR.G -> nGTR (remove prefix and suffix)
-      peptide = stringr::str_sub(.data$peptide, 3L, -3L),
-      # Remove all other modifications like C[+57.02146] -> C
-      peptide = stringr::str_remove_all(.data$peptide, "\\[.+?\\]"),
-      # Extract peptide site (position of glycosylated residue)
-      peptide_site = stringr::str_locate(.data$peptide, "n")[, "start"],
-      # nGTR -> NGTR (restore N)
-      peptide = stringr::str_replace(.data$peptide, "n", "N"),
-      # >sp|P19652|A1AG2_HUMAN -> P19652, >sp|P08185-1|CBG_HUMAN -> P08185-1
-      protein = .extract_uniprot_accession(.data$protein),
-      # HexNAc(4)Hex(4)Fuc(1)NeuAc(1) -> HexNAc(4)Hex(4)dHex(1)NeuAc(1)
-      glycan_composition = stringr::str_replace(
-        .data$glycan_composition,
-        "Fuc",
-        "dHex"
-      )
-    )
-
-  # Set protein_site to NA for multisite glycopeptides (if is_multisite column exists)
-  if ("is_multisite" %in% colnames(result)) {
-    result <- dplyr::mutate(
-      result,
-      protein_site = dplyr::if_else(
-        .data$is_multisite,
-        NA_integer_,
-        .data$protein_site
-      )
-    )
+  expanded_cols <- c("gp_id", "glycan_composition", "peptide_site", "protein_site")
+  if (!all(expanded_cols %in% colnames(df))) {
+    df <- .expand_byonic_pglycoquant_multisite_rows(df)
   }
 
+  result <- df %>%
+    dplyr::mutate(
+      peptide = .clean_byonic_pglycoquant_peptide(.data$Peptide),
+      # >sp|P19652|A1AG2_HUMAN -> P19652, >sp|P08185-1|CBG_HUMAN -> P08185-1
+      protein = .extract_uniprot_accession(.data$`Protein Name`)
+    )
+
   result
+}
+
+#' Split Byonic-pGlycoQuant glycan compositions by site
+#'
+#' @param glycans A single Byonic-pGlycoQuant glycan composition string.
+#'
+#' @returns A character vector with one glycan composition per site.
+#' @noRd
+.split_byonic_pglycoquant_glycans <- function(glycans) {
+  if (is.na(glycans)) {
+    return(NA_character_)
+  }
+
+  glycans %>%
+    stringr::str_replace_all("Fuc", "dHex") %>%
+    stringr::str_split(stringr::fixed(","), simplify = FALSE) %>%
+    purrr::pluck(1) %>%
+    stringr::str_trim()
+}
+
+#' Extract glycosylated peptide sites from a Byonic peptide
+#'
+#' @param peptide A Byonic peptide string with flanking residues.
+#'
+#' @returns An integer vector of peptide positions carrying glycans.
+#' @noRd
+.extract_byonic_pglycoquant_glycosites <- function(peptide) {
+  if (is.na(peptide)) {
+    return(NA_integer_)
+  }
+
+  peptide_core <- .extract_byonic_pglycoquant_peptide_core(peptide)
+  glycan_matches <- stringr::str_locate_all(peptide_core, "N\\[[^\\]]+\\]")[[1]]
+
+  if (nrow(glycan_matches) > 0) {
+    return(purrr::map_int(
+      glycan_matches[, "start"],
+      \(match_start) {
+        prefix <- stringr::str_sub(peptide_core, 1L, match_start)
+        nchar(stringr::str_remove_all(prefix, "\\[[^\\]]+\\]"))
+      }
+    ))
+  }
+
+  lowercase_n_matches <- stringr::str_locate_all(peptide_core, "n")[[1]]
+  as.integer(lowercase_n_matches[, "start"])
+}
+
+#' Remove flanking residues and modifications from a Byonic peptide
+#'
+#' @param peptide A Byonic peptide string with flanking residues.
+#'
+#' @returns A clean uppercase peptide sequence.
+#' @noRd
+.clean_byonic_pglycoquant_peptide <- function(peptide) {
+  peptide %>%
+    .extract_byonic_pglycoquant_peptide_core() %>%
+    stringr::str_remove_all("\\[[^\\]]+\\]") %>%
+    stringr::str_to_upper()
+}
+
+#' Extract the peptide core from a Byonic peptide
+#'
+#' @param peptide A Byonic peptide string with flanking residues.
+#'
+#' @returns The peptide sequence between flanking residues.
+#' @noRd
+.extract_byonic_pglycoquant_peptide_core <- function(peptide) {
+  stringr::str_sub(peptide, 3L, -3L)
+}
+
+#' Check glycan-site pairing in Byonic-pGlycoQuant rows
+#'
+#' @param df A Byonic-pGlycoQuant tibble with list columns for glycan
+#'   compositions and peptide sites.
+#'
+#' @returns The input tibble, invisibly checked.
+#' @noRd
+.check_byonic_pglycoquant_glycosite_pairing <- function(df) {
+  invalid_rows <- which(df$n_glycans != df$n_sites)
+  if (length(invalid_rows) > 0) {
+    rlang::abort(c(
+      "Cannot pair Byonic-pGlycoQuant glycan compositions with glycosylation sites.",
+      i = "The number of comma-separated glycans must match the number of glycosylated N sites in `Peptide`.",
+      x = glue::glue("Problematic rows: {toString(invalid_rows)}")
+    ))
+  }
+
+  df
 }

--- a/R/byonic-pglycoquant.R
+++ b/R/byonic-pglycoquant.R
@@ -147,7 +147,6 @@ read_byonic_pglycoquant <- function(
         .data$Peptide,
         .extract_byonic_pglycoquant_glycosites
       ),
-      first_peptide_site = purrr::map_int(.data$peptide_site, min),
       n_glycans = purrr::map_int(.data$glycan_composition, length),
       n_sites = purrr::map_int(.data$peptide_site, length)
     ) %>%
@@ -155,6 +154,7 @@ read_byonic_pglycoquant <- function(
       source = "Byonic-pGlycoQuant",
       site_column = "Peptide"
     ) %>%
+    dplyr::mutate(first_peptide_site = purrr::map_int(.data$peptide_site, min)) %>%
     tidyr::unnest_longer(c("glycan_composition", "peptide_site")) %>%
     dplyr::mutate(
       peptide_site = as.integer(.data$peptide_site),

--- a/R/byonic-pglycoquant.R
+++ b/R/byonic-pglycoquant.R
@@ -156,7 +156,9 @@ read_byonic_pglycoquant <- function(
       source = "Byonic-pGlycoQuant",
       site_column = "Peptide"
     ) %>%
-    dplyr::mutate(first_peptide_site = purrr::map_int(.data$peptide_site, min)) %>%
+    dplyr::mutate(
+      first_peptide_site = purrr::map_int(.data$peptide_site, min)
+    ) %>%
     tidyr::unnest_longer(c("glycan_composition", "peptide_site")) %>%
     dplyr::mutate(
       peptide_site = as.integer(.data$peptide_site),

--- a/R/byonic-utils.R
+++ b/R/byonic-utils.R
@@ -1,0 +1,44 @@
+#' Split Byonic glycan compositions by glycosylation site
+#'
+#' @param glycans A single comma-separated Byonic glycan composition string.
+#'
+#' @returns A character vector with one glycan composition per site.
+#' @noRd
+.split_byonic_glycan_compositions <- function(glycans) {
+  if (is.na(glycans)) {
+    return(NA_character_)
+  }
+
+  glycans %>%
+    stringr::str_replace_all("Fuc", "dHex") %>%
+    stringr::str_split(stringr::fixed(","), simplify = FALSE) %>%
+    purrr::pluck(1) %>%
+    stringr::str_trim()
+}
+
+#' Check glycan-site pairing in expanded Byonic rows
+#'
+#' @param df A tibble with `n_glycans` and `n_sites` columns.
+#' @param source Human-readable source name for error messages.
+#' @param site_column Source column that carries the glycosylation sites.
+#' @param row_id Row identifiers to report on mismatch.
+#'
+#' @returns The input tibble, invisibly checked.
+#' @noRd
+.check_byonic_glycan_site_pairing <- function(
+  df,
+  source,
+  site_column,
+  row_id = seq_len(nrow(df))
+) {
+  invalid_rows <- row_id[df$n_glycans != df$n_sites]
+  if (length(invalid_rows) > 0) {
+    rlang::abort(c(
+      "Cannot pair {source} glycan compositions with glycosylation sites.",
+      i = "The number of comma-separated glycans must match the number of glycosylation sites in `.field {site_column}`.",
+      x = "Problematic rows: {.val {toString(invalid_rows)}}"
+    ))
+  }
+
+  df
+}

--- a/R/byonic-utils.R
+++ b/R/byonic-utils.R
@@ -16,6 +16,31 @@
     stringr::str_trim()
 }
 
+#' Drop multisite Byonic rows when requested
+#'
+#' @param df A Byonic result tibble.
+#' @param glycan_col Name of the column containing glycan compositions.
+#' @param source Human-readable source name for messages.
+#'
+#' @returns The input tibble with multisite rows removed.
+#' @noRd
+.drop_byonic_multisite_rows <- function(df, glycan_col, source) {
+  is_multisite <- stringr::str_detect(df[[glycan_col]], stringr::fixed(","))
+  n_multisite <- sum(is_multisite, na.rm = TRUE)
+
+  if (n_multisite > 0) {
+    perc_multisite <- round(n_multisite / nrow(df) * 100, 1)
+    cli::cli_alert_info(
+      "Dropping {.val {n_multisite}} of {.val {nrow(df)}} ({.val {perc_multisite}}%) multisite {source} rows."
+    )
+  }
+
+  df %>%
+    dplyr::mutate(.byonic_is_multisite = is_multisite) %>%
+    dplyr::filter(!.data$.byonic_is_multisite) %>%
+    dplyr::select(-all_of(".byonic_is_multisite"))
+}
+
 #' Check glycan-site pairing in expanded Byonic rows
 #'
 #' @param df A tibble with `n_glycans` and `n_sites` columns.

--- a/R/byonic-utils.R
+++ b/R/byonic-utils.R
@@ -23,7 +23,7 @@
 #' @param site_column Source column that carries the glycosylation sites.
 #' @param row_id Row identifiers to report on mismatch.
 #'
-#' @returns The input tibble, invisibly checked.
+#' @returns The input tibble.
 #' @noRd
 .check_byonic_glycan_site_pairing <- function(
   df,
@@ -33,9 +33,9 @@
 ) {
   invalid_rows <- row_id[df$n_glycans != df$n_sites]
   if (length(invalid_rows) > 0) {
-    rlang::abort(c(
+    cli::cli_abort(c(
       "Cannot pair {source} glycan compositions with glycosylation sites.",
-      i = "The number of comma-separated glycans must match the number of glycosylation sites in `.field {site_column}`.",
+      i = "The number of comma-separated glycans must match the number of glycosylation sites in {.field {site_column}}.",
       x = "Problematic rows: {.val {toString(invalid_rows)}}"
     ))
   }

--- a/man/read_byonic_byologic.Rd
+++ b/man/read_byonic_byologic.Rd
@@ -10,7 +10,8 @@ read_byonic_byologic(
   quant_method = "label-free",
   glycan_type = "N",
   sample_name_converter = NULL,
-  orgdb = "org.Hs.eg.db"
+  orgdb = "org.Hs.eg.db",
+  multisite = "expand"
 )
 }
 \arguments{
@@ -32,6 +33,12 @@ If NULL, original names are kept.}
 
 \item{orgdb}{name of the OrgDb package to use for UniProt to gene symbol conversion.
 Default is "org.Hs.eg.db".}
+
+\item{multisite}{How to handle multisite glycopeptides.
+\itemize{
+\item "expand" (default) expands each multisite glycopeptide into site-specific rows.
+\item "drop" removes multisite glycopeptides.
+}}
 }
 \value{
 An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
@@ -53,9 +60,9 @@ The exported .csv file is the file you should use.
 \section{Multisite glycopeptides}{
 
 Some glycopeptides can have more than one glycosylation site.
-In this case, it will be expanded into multiple rows with the same quantification value
+By default, they are expanded into multiple rows with the same quantification value
 but different \code{protein_site} and \code{glycan_composition}.
-This is generally fine if downstream analyses are done at the glycoform level.
+Set \code{multisite = "drop"} to remove multisite glycopeptides instead.
 }
 
 \section{Variable information}{

--- a/man/read_byonic_byologic.Rd
+++ b/man/read_byonic_byologic.Rd
@@ -56,8 +56,6 @@ Some glycopeptides can have more than one glycosylation site.
 In this case, it will be expanded into multiple rows with the same quantification value
 but different \code{protein_site} and \code{glycan_composition}.
 This is generally fine if downstream analyses are done at the glycoform level.
-A \code{gp_id} column is also added to uniquely identify each glycopeptide before row expansion,
-so that the multiple rows can be mapped back to the original glycopeptide if needed.
 }
 
 \section{Variable information}{
@@ -70,7 +68,6 @@ The following columns could be found in the variable information tibble:
 \item \code{protein_site}: integer, site of glycosylation on protein
 \item \code{gene}: character, gene name (symbol)
 \item \code{glycan_composition}: \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}, glycan compositions.
-\item \code{gp_id}: character, glycopeptide ID before multisite row expansion.
 }
 }
 

--- a/man/read_byonic_byologic.Rd
+++ b/man/read_byonic_byologic.Rd
@@ -52,8 +52,12 @@ The exported .csv file is the file you should use.
 
 \section{Multisite glycopeptides}{
 
-Multisite glycopeptides are supported but their \code{protein_site} will be set to \code{NA}
-since the exact site of glycosylation cannot be determined unambiguously.
+Some glycopeptides can have more than one glycosylation site.
+In this case, it will be expanded into multiple rows with the same quantification value
+but different \code{protein_site} and \code{glycan_composition}.
+This is generally fine if downstream analyses are done at the glycoform level.
+A \code{gp_id} column is also added to uniquely identify each glycopeptide before row expansion,
+so that the multiple rows can be mapped back to the original glycopeptide if needed.
 }
 
 \section{Variable information}{
@@ -66,6 +70,7 @@ The following columns could be found in the variable information tibble:
 \item \code{protein_site}: integer, site of glycosylation on protein
 \item \code{gene}: character, gene name (symbol)
 \item \code{glycan_composition}: \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}, glycan compositions.
+\item \code{gp_id}: character, glycopeptide ID before multisite row expansion.
 }
 }
 

--- a/man/read_byonic_pglycoquant.Rd
+++ b/man/read_byonic_pglycoquant.Rd
@@ -62,8 +62,6 @@ Some glycopeptides can have more than one glycosylation site.
 In this case, it will be expanded into multiple rows with the same quantification value
 but different \code{protein_site} and \code{glycan_composition}.
 This is generally fine if downstream analyses are done at the glycoform level.
-A \code{gp_id} column is also added to uniquely identify each glycopeptide before row expansion,
-so that the multiple rows can be mapped back to the original glycopeptide if needed.
 }
 
 \section{Variable information}{
@@ -77,7 +75,6 @@ The following columns could be found in the variable information tibble:
 \item \code{gene}: character, gene name (symbol)
 \item \code{glycan_composition}: \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}, glycan compositions.
 \item \code{glycan_structure}: \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}, glycan structures (if \code{parse_structure = TRUE}).
-\item \code{gp_id}: character, glycopeptide ID before multisite row expansion.
 }
 }
 

--- a/man/read_byonic_pglycoquant.Rd
+++ b/man/read_byonic_pglycoquant.Rd
@@ -58,8 +58,12 @@ the manual: \href{https://github.com/Power-Quant/pGlycoQuant/blob/main/Manual\%2
 
 \section{Multisite glycopeptides}{
 
-Multisite glycopeptides are supported but their \code{protein_site} will be set to \code{NA}
-since the exact site of glycosylation cannot be determined unambiguously.
+Some glycopeptides can have more than one glycosylation site.
+In this case, it will be expanded into multiple rows with the same quantification value
+but different \code{protein_site} and \code{glycan_composition}.
+This is generally fine if downstream analyses are done at the glycoform level.
+A \code{gp_id} column is also added to uniquely identify each glycopeptide before row expansion,
+so that the multiple rows can be mapped back to the original glycopeptide if needed.
 }
 
 \section{Variable information}{
@@ -73,6 +77,7 @@ The following columns could be found in the variable information tibble:
 \item \code{gene}: character, gene name (symbol)
 \item \code{glycan_composition}: \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}, glycan compositions.
 \item \code{glycan_structure}: \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}, glycan structures (if \code{parse_structure = TRUE}).
+\item \code{gp_id}: character, glycopeptide ID before multisite row expansion.
 }
 }
 

--- a/man/read_byonic_pglycoquant.Rd
+++ b/man/read_byonic_pglycoquant.Rd
@@ -11,7 +11,8 @@ read_byonic_pglycoquant(
   glycan_type = "N",
   sample_name_converter = NULL,
   orgdb = "org.Hs.eg.db",
-  parse_structure = TRUE
+  parse_structure = TRUE,
+  multisite = "expand"
 )
 }
 \arguments{
@@ -38,6 +39,12 @@ Default is "org.Hs.eg.db".}
 If \code{TRUE}, glycan structures are parsed and included in the
 \code{var_info} as \code{glycan_structure} column. If \code{FALSE} (default), structure parsing
 is skipped and structure-related columns are removed.}
+
+\item{multisite}{How to handle multisite glycopeptides.
+\itemize{
+\item "expand" (default) expands each multisite glycopeptide into site-specific rows.
+\item "drop" removes multisite glycopeptides.
+}}
 }
 \value{
 An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
@@ -59,9 +66,9 @@ the manual: \href{https://github.com/Power-Quant/pGlycoQuant/blob/main/Manual\%2
 \section{Multisite glycopeptides}{
 
 Some glycopeptides can have more than one glycosylation site.
-In this case, it will be expanded into multiple rows with the same quantification value
+By default, they are expanded into multiple rows with the same quantification value
 but different \code{protein_site} and \code{glycan_composition}.
-This is generally fine if downstream analyses are done at the glycoform level.
+Set \code{multisite = "drop"} to remove multisite glycopeptides instead.
 }
 
 \section{Variable information}{

--- a/tests/testthat/test-aggregate-utils.R
+++ b/tests/testthat/test-aggregate-utils.R
@@ -1,4 +1,4 @@
-test_that("gp_id is retained as trace metadata without splitting aggregation", {
+test_that("aggregation ignores trace columns and sums glycopeptide values", {
   tidy_df <- tibble::tibble(
     peptide = "NTEST",
     peptide_site = 1L,
@@ -14,10 +14,10 @@ test_that("gp_id is retained as trace metadata without splitting aggregation", {
 
   expect_equal(nrow(res), 1L)
   expect_equal(res$value, 30)
-  expect_equal(res$gp_id, "GP1;GP2")
+  expect_false("gp_id" %in% colnames(res))
 })
 
-test_that("gp_id trace metadata is stable across samples", {
+test_that("aggregation keeps sample-level values separate", {
   tidy_df <- tibble::tibble(
     peptide = "NTEST",
     peptide_site = 1L,
@@ -32,5 +32,6 @@ test_that("gp_id trace metadata is stable across samples", {
   res <- glyread:::.aggregate_long(tidy_df)
 
   expect_equal(nrow(res), 2L)
-  expect_equal(unique(res$gp_id), "GP1;GP2")
+  expect_false("gp_id" %in% colnames(res))
+  expect_equal(res$value, c(10, 20))
 })

--- a/tests/testthat/test-aggregate-utils.R
+++ b/tests/testthat/test-aggregate-utils.R
@@ -1,0 +1,36 @@
+test_that("gp_id is retained as trace metadata without splitting aggregation", {
+  tidy_df <- tibble::tibble(
+    peptide = "NTEST",
+    peptide_site = 1L,
+    protein = "P12345",
+    protein_site = 10L,
+    glycan_composition = "HexNAc(1)",
+    gp_id = c("GP1", "GP2"),
+    sample = "S1",
+    value = c(10, 20)
+  )
+
+  res <- glyread:::.aggregate_long(tidy_df)
+
+  expect_equal(nrow(res), 1L)
+  expect_equal(res$value, 30)
+  expect_equal(res$gp_id, "GP1;GP2")
+})
+
+test_that("gp_id trace metadata is stable across samples", {
+  tidy_df <- tibble::tibble(
+    peptide = "NTEST",
+    peptide_site = 1L,
+    protein = "P12345",
+    protein_site = 10L,
+    glycan_composition = "HexNAc(1)",
+    gp_id = c("GP1", "GP2"),
+    sample = c("S1", "S2"),
+    value = c(10, 20)
+  )
+
+  res <- glyread:::.aggregate_long(tidy_df)
+
+  expect_equal(nrow(res), 2L)
+  expect_equal(unique(res$gp_id), "GP1;GP2")
+})

--- a/tests/testthat/test-byonic-byologic.R
+++ b/tests/testthat/test-byonic-byologic.R
@@ -95,8 +95,7 @@ test_that("multisite glycopeptides are expanded into site-specific rows", {
   res$var_info <- dplyr::arrange(res$var_info, .data$protein_site)
 
   expect_equal(nrow(res$var_info), 2L)
-  expect_true("gp_id" %in% colnames(res$var_info))
-  expect_equal(length(unique(res$var_info$gp_id)), 1L)
+  expect_false("gp_id" %in% colnames(res$var_info))
   expect_equal(res$var_info$peptide_site, c(5L, 9L))
   expect_equal(res$var_info$protein_site, c(14L, 18L))
   expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")

--- a/tests/testthat/test-byonic-byologic.R
+++ b/tests/testthat/test-byonic-byologic.R
@@ -57,23 +57,54 @@ test_that("multisite glycopeptides are handled correctly in full workflow", {
   # All entries should be present (multisite glycopeptides are no longer filtered out)
   expect_true(nrow(res$var_info) > 0)
 
-  # If there were multisite glycopeptides (indicated by commas in compositions),
-  # their protein_site should be NA, but this test data doesn't contain any
+  # Multisite glycopeptides should be expanded before composition parsing,
+  # so parsed output should not retain comma-separated compositions.
   compositions <- as.character(res$var_info$glycan_composition)
   multisite_entries <- stringr::str_detect(compositions, ",")
+  expect_false(any(multisite_entries))
 
-  if (any(multisite_entries)) {
-    # For multisite entries, protein_site should be NA
-    multisite_protein_sites <- res$var_info$protein_site[multisite_entries]
-    expect_true(all(is.na(multisite_protein_sites)))
-  }
+  # Expanded entries should have valid protein_site values.
+  expect_true(all(!is.na(res$var_info$protein_site)))
+})
 
-  # Single-site entries should have valid protein_site values
-  singlesite_entries <- !multisite_entries
-  if (any(singlesite_entries)) {
-    singlesite_protein_sites <- res$var_info$protein_site[singlesite_entries]
-    expect_true(all(!is.na(singlesite_protein_sites)))
-  }
+
+test_that("multisite glycopeptides are expanded into site-specific rows", {
+  byologic_path <- withr::local_tempfile(fileext = ".csv")
+  readr::write_csv(
+    tibble::tibble(
+      row_number = "1",
+      protein_name = "sp|P02765|FETUA_HUMAN",
+      sequence = "K.ABCDnEFGHnIK.R",
+      glycans = "HexNAc(1)Fuc(1),HexNAc(4)Hex(5)Fuc(1)NeuAc(1)",
+      xic_area_summed = 100,
+      ms_alias_name = "Sample1",
+      mod_summary = "N5(NGlycan/349.1373); N9(NGlycan/2059.7349)",
+      start_aa = 10L
+    ),
+    byologic_path
+  )
+
+  suppressMessages(
+    res <- read_byonic_byologic(
+      byologic_path,
+      quant_method = "label-free",
+      orgdb = "missing.OrgDb"
+    )
+  )
+
+  res$var_info <- dplyr::arrange(res$var_info, .data$protein_site)
+
+  expect_equal(nrow(res$var_info), 2L)
+  expect_true("gp_id" %in% colnames(res$var_info))
+  expect_equal(length(unique(res$var_info$gp_id)), 1L)
+  expect_equal(res$var_info$peptide_site, c(5L, 9L))
+  expect_equal(res$var_info$protein_site, c(14L, 18L))
+  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_equal(
+    as.character(res$var_info$glycan_composition),
+    c("HexNAc(1)dHex(1)", "Hex(5)HexNAc(4)dHex(1)NeuAc(1)")
+  )
+  expect_equal(as.numeric(res$expr_mat[, "Sample1"]), c(100, 100))
 })
 
 

--- a/tests/testthat/test-byonic-byologic.R
+++ b/tests/testthat/test-byonic-byologic.R
@@ -106,6 +106,44 @@ test_that("multisite glycopeptides are expanded into site-specific rows", {
   expect_equal(as.numeric(res$expr_mat[, "Sample1"]), c(100, 100))
 })
 
+test_that("multisite glycopeptides can be dropped", {
+  byologic_path <- withr::local_tempfile(fileext = ".csv")
+  readr::write_csv(
+    tibble::tibble(
+      row_number = c("1", "2"),
+      protein_name = "sp|P02765|FETUA_HUMAN",
+      sequence = c("K.ABCDnEFGHnIK.R", "K.ABCDnEF.R"),
+      glycans = c(
+        "HexNAc(1)Fuc(1),HexNAc(4)Hex(5)Fuc(1)NeuAc(1)",
+        "HexNAc(1)Fuc(1)"
+      ),
+      xic_area_summed = c(100, 50),
+      ms_alias_name = "Sample1",
+      mod_summary = c(
+        "N5(NGlycan/349.1373); N9(NGlycan/2059.7349)",
+        "N5(NGlycan/349.1373)"
+      ),
+      start_aa = 10L
+    ),
+    byologic_path
+  )
+
+  suppressMessages(
+    res <- read_byonic_byologic(
+      byologic_path,
+      quant_method = "label-free",
+      orgdb = "missing.OrgDb",
+      multisite = "drop"
+    )
+  )
+
+  expect_equal(nrow(res$var_info), 1L)
+  expect_equal(res$var_info$peptide_site, 5L)
+  expect_equal(res$var_info$protein_site, 14L)
+  expect_equal(as.character(res$var_info$glycan_composition), "HexNAc(1)dHex(1)")
+  expect_equal(as.numeric(res$expr_mat[, "Sample1"]), 50)
+})
+
 
 # ----- Row hierarchy collapse -----
 test_that("hierarchical rows are correctly collapsed", {

--- a/tests/testthat/test-byonic-byologic.R
+++ b/tests/testthat/test-byonic-byologic.R
@@ -140,7 +140,10 @@ test_that("multisite glycopeptides can be dropped", {
   expect_equal(nrow(res$var_info), 1L)
   expect_equal(res$var_info$peptide_site, 5L)
   expect_equal(res$var_info$protein_site, 14L)
-  expect_equal(as.character(res$var_info$glycan_composition), "HexNAc(1)dHex(1)")
+  expect_equal(
+    as.character(res$var_info$glycan_composition),
+    "HexNAc(1)dHex(1)"
+  )
   expect_equal(as.numeric(res$expr_mat[, "Sample1"]), 50)
 })
 

--- a/tests/testthat/test-byonic-pglycoquant.R
+++ b/tests/testthat/test-byonic-pglycoquant.R
@@ -94,6 +94,44 @@ test_that("multisite Byonic-pGlycoQuant glycopeptides are expanded into site-spe
   expect_equal(as.numeric(res$expr_mat[, "Sample1"]), c(100, 100))
 })
 
+test_that("multisite Byonic-pGlycoQuant glycopeptides can be dropped", {
+  pglycoquant_path <- withr::local_tempfile(fileext = ".list")
+  readr::write_tsv(
+    tibble::tibble(
+      Peptide = c(
+        "K.NLFLN[+349.13728]HSEN[+2059.73493]ATAK.D",
+        "K.N[+203.07937]GTR.G"
+      ),
+      `Protein Name` = c(
+        ">tr|H0Y300|H0Y300_HUMAN Haptoglobin OS=Homo sapiens OX=9606 GN=HP PE=1 SV=4",
+        ">tr|A0A024R6P0|A0A024R6P0_HUMAN Serpin peptidase inhibitor, clade A, member 3 OS=Homo sapiens OX=9606 GN=SERPINA3 PE=3 SV=1"
+      ),
+      Position = c(239L, 186L),
+      Composition = c(
+        "HexNAc(1)Fuc(1),HexNAc(4)Hex(5)Fuc(1)NeuAc(1)",
+        "HexNAc(1)"
+      ),
+      `Intensity(Sample1)` = c(100, 50)
+    ),
+    pglycoquant_path
+  )
+
+  suppressMessages(
+    res <- read_byonic_pglycoquant(
+      pglycoquant_path,
+      quant_method = "label-free",
+      orgdb = "missing.OrgDb",
+      multisite = "drop"
+    )
+  )
+
+  expect_equal(nrow(res$var_info), 1L)
+  expect_equal(res$var_info$peptide_site, 1L)
+  expect_equal(res$var_info$protein_site, 186L)
+  expect_equal(as.character(res$var_info$glycan_composition), "HexNAc(1)")
+  expect_equal(as.numeric(res$expr_mat[, "Sample1"]), 50)
+})
+
 test_that("Byonic-pGlycoQuant rows without glycosite markers fail clearly", {
   malformed_df <- tibble::tibble(
     Peptide = "K.NLFLNHSENATAK.D",

--- a/tests/testthat/test-byonic-pglycoquant.R
+++ b/tests/testthat/test-byonic-pglycoquant.R
@@ -83,8 +83,7 @@ test_that("multisite Byonic-pGlycoQuant glycopeptides are expanded into site-spe
   res$var_info <- dplyr::arrange(res$var_info, .data$protein_site)
 
   expect_equal(nrow(res$var_info), 2L)
-  expect_true("gp_id" %in% colnames(res$var_info))
-  expect_equal(length(unique(res$var_info$gp_id)), 1L)
+  expect_false("gp_id" %in% colnames(res$var_info))
   expect_equal(res$var_info$peptide_site, c(5L, 9L))
   expect_equal(res$var_info$protein_site, c(239L, 243L))
   expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")

--- a/tests/testthat/test-byonic-pglycoquant.R
+++ b/tests/testthat/test-byonic-pglycoquant.R
@@ -95,6 +95,21 @@ test_that("multisite Byonic-pGlycoQuant glycopeptides are expanded into site-spe
   expect_equal(as.numeric(res$expr_mat[, "Sample1"]), c(100, 100))
 })
 
+test_that("Byonic-pGlycoQuant rows without glycosite markers fail clearly", {
+  malformed_df <- tibble::tibble(
+    Peptide = "K.NLFLNHSENATAK.D",
+    `Protein Name` = ">tr|H0Y300|H0Y300_HUMAN Haptoglobin OS=Homo sapiens OX=9606 GN=HP PE=1 SV=4",
+    Position = 239L,
+    Composition = "HexNAc(1)Fuc(1),HexNAc(4)Hex(5)Fuc(1)NeuAc(1)",
+    `Intensity(Sample1)` = 100
+  )
+
+  expect_error(
+    glyread:::.expand_byonic_pglycoquant_multisite_rows(malformed_df),
+    "Cannot pair Byonic-pGlycoQuant glycan compositions with glycosylation sites"
+  )
+})
+
 # ----- Peptide site calculation -----
 test_that("peptide_site and protein_site are correctly calculated", {
   suppressMessages(

--- a/tests/testthat/test-byonic-pglycoquant.R
+++ b/tests/testthat/test-byonic-pglycoquant.R
@@ -49,23 +49,50 @@ test_that("multisite glycopeptides are handled correctly in full workflow", {
   # All entries should be present (multisite glycopeptides are no longer filtered out)
   expect_true(nrow(res$var_info) > 0)
 
-  # If there were multisite glycopeptides (indicated by commas in compositions),
-  # their protein_site should be NA, but this test data doesn't contain any
+  # Multisite glycopeptides should be expanded before composition parsing,
+  # so parsed output should not retain comma-separated compositions.
   compositions <- as.character(res$var_info$glycan_composition)
   multisite_entries <- stringr::str_detect(compositions, ",")
+  expect_false(any(multisite_entries))
 
-  if (any(multisite_entries)) {
-    # For multisite entries, protein_site should be NA
-    multisite_protein_sites <- res$var_info$protein_site[multisite_entries]
-    expect_true(all(is.na(multisite_protein_sites)))
-  }
+  # Expanded entries should have valid protein_site values.
+  expect_true(all(!is.na(res$var_info$protein_site)))
+})
 
-  # Single-site entries should have valid protein_site values
-  singlesite_entries <- !multisite_entries
-  if (any(singlesite_entries)) {
-    singlesite_protein_sites <- res$var_info$protein_site[singlesite_entries]
-    expect_true(all(!is.na(singlesite_protein_sites)))
-  }
+test_that("multisite Byonic-pGlycoQuant glycopeptides are expanded into site-specific rows", {
+  pglycoquant_path <- withr::local_tempfile(fileext = ".list")
+  readr::write_tsv(
+    tibble::tibble(
+      Peptide = "K.NLFLN[+349.13728]HSEN[+2059.73493]ATAK.D",
+      `Protein Name` = ">tr|H0Y300|H0Y300_HUMAN Haptoglobin OS=Homo sapiens OX=9606 GN=HP PE=1 SV=4",
+      Position = 239L,
+      Composition = "HexNAc(1)Fuc(1),HexNAc(4)Hex(5)Fuc(1)NeuAc(1)",
+      `Intensity(Sample1)` = 100
+    ),
+    pglycoquant_path
+  )
+
+  suppressMessages(
+    res <- read_byonic_pglycoquant(
+      pglycoquant_path,
+      quant_method = "label-free",
+      orgdb = "missing.OrgDb"
+    )
+  )
+
+  res$var_info <- dplyr::arrange(res$var_info, .data$protein_site)
+
+  expect_equal(nrow(res$var_info), 2L)
+  expect_true("gp_id" %in% colnames(res$var_info))
+  expect_equal(length(unique(res$var_info$gp_id)), 1L)
+  expect_equal(res$var_info$peptide_site, c(5L, 9L))
+  expect_equal(res$var_info$protein_site, c(239L, 243L))
+  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_equal(
+    as.character(res$var_info$glycan_composition),
+    c("HexNAc(1)dHex(1)", "Hex(5)HexNAc(4)dHex(1)NeuAc(1)")
+  )
+  expect_equal(as.numeric(res$expr_mat[, "Sample1"]), c(100, 100))
 })
 
 # ----- Peptide site calculation -----

--- a/tests/testthat/test-uniprot-parsing.R
+++ b/tests/testthat/test-uniprot-parsing.R
@@ -1,7 +1,7 @@
 # Test UniProt identifier parsing functions
 
 # ----- Test byonic-pglycoquant UniProt parsing -----
-test_that(".convert_byonic_columns correctly extracts UniProt accessions", {
+test_that(".standardize_byonic_pglycoquant_columns correctly extracts UniProt accessions", {
   # Create test data with various UniProt formats
   test_df <- tibble::tibble(
     `Protein Name` = c(
@@ -16,8 +16,10 @@ test_that(".convert_byonic_columns correctly extracts UniProt accessions", {
     Position = rep(123L, 5)
   )
 
-  # Apply the conversion function
-  result <- glyread:::.convert_byonic_columns(test_df)
+  # Apply the pGlycoQuant row expansion and column-standardization helpers.
+  result <- test_df %>%
+    glyread:::.expand_byonic_pglycoquant_multisite_rows() %>%
+    glyread:::.standardize_byonic_pglycoquant_columns()
 
   # Check that accessions are correctly extracted
   expected_proteins <- c(
@@ -116,7 +118,9 @@ test_that("UniProt parsing handles edge cases correctly", {
     Position = rep(123L, 4)
   )
 
-  result_byonic <- glyread:::.convert_byonic_columns(test_df_byonic)
+  result_byonic <- test_df_byonic %>%
+    glyread:::.expand_byonic_pglycoquant_multisite_rows() %>%
+    glyread:::.standardize_byonic_pglycoquant_columns()
 
   # Should extract valid accession and handle malformed entries gracefully
   expect_equal(result_byonic$protein[1], "P08185")

--- a/tests/testthat/test-uniprot-parsing.R
+++ b/tests/testthat/test-uniprot-parsing.R
@@ -70,7 +70,7 @@ test_that(".convert_pglyco3_columns correctly extracts UniProt accessions", {
 })
 
 # ----- Test byonic-byologic UniProt parsing -----
-test_that(".refine_byonic_byologic_columns correctly extracts UniProt accessions", {
+test_that(".standardize_byologic_columns correctly extracts UniProt accessions", {
   # Create test data with various UniProt formats
   test_df <- tibble::tibble(
     protein_name = c(
@@ -87,8 +87,10 @@ test_that(".refine_byonic_byologic_columns correctly extracts UniProt accessions
     xic_area_summed = rep(1000.0, 4)
   )
 
-  # Apply the conversion function
-  result <- glyread:::.refine_byonic_byologic_columns(test_df)
+  # Apply the Byologic row expansion and column-standardization helpers.
+  result <- test_df %>%
+    glyread:::.expand_byologic_multisite_rows() %>%
+    glyread:::.standardize_byologic_columns()
 
   # Check that accessions are correctly extracted
   expected_proteins <- c("P08185", "P08185-1", "A0A024R6P0", "Q9Y6R7-2")


### PR DESCRIPTION
## Summary
- Updated `read_byonic_byologic()` and `read_byonic_pglycoquant()` to handle multisite glycopeptides by expanding them into site-specific rows with shared `gp_id`, site-specific `protein_site`, and site-specific `glycan_composition`.
- Added regression coverage using representative multisite Byologic and Byonic-pGlycoQuant examples.
- Refactored the Byonic internals afterward so the two readers share glycan-splitting and glycan/site pairing helpers while keeping each reader pipeline explicit.

## Testing
- `devtools::test(filter = "byonic-byologic|byonic-pglycoquant|uniprot-parsing")` passed.
- `devtools::test()` passed.
- `codetools::checkUsagePackage("glyread")` no longer reports the `.` binding NOTE for the Byologic multisite helper.