### PR TITLE
feat: return GlycomicSE and GlycoproteomicSE objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,12 +11,13 @@ Description: Provides a unified interface for reading and processing
     The package standardizes raw data from different sources, performs
     peptide-spectrum match (PSM) aggregation, parses glycan compositions
     and structures, and converts the data into a standardized
-    experiment object from the 'glyexp' package for downstream analysis
-    within the glycoverse ecosystem.
+    'GlycomicSE' and 'GlycoproteomicSE' objects from the 'glyexp' package
+    for downstream analysis within the glycoverse ecosystem.
 License: MIT + file LICENSE
 Suggests: 
     knitr,
     rmarkdown,
+    SummarizedExperiment,
     testthat (>= 3.0.0),
     withr
 Config/testthat/edition: 3
@@ -30,7 +31,7 @@ Imports:
     cli,
     dplyr,
     fs,
-    glyexp (>= 0.12.1),
+    glyexp (>= 0.15.0),
     glyparse (>= 0.5.3),
     glyrepr (>= 0.7.4),
     janitor,
@@ -39,6 +40,7 @@ Imports:
     readr,
     readxl,
     rlang,
+    S4Vectors,
     stringr,
     tibble,
     tidyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # glyread (development version)
 
+## Breaking changes
+
+* All `read_*()` functions now return `glyexp::GlycomicSE` or `glyexp::GlycoproteomicSE` objects; code using legacy `glyexp::experiment()` fields must migrate to `SummarizedExperiment` assays, `rowData`, `colData`, and metadata. This is Stage II of glyexp#15.
+
+## New features
+
+* `read_glyhunter()` now returns `glyexp::GlycomicSE`, while all glycoproteomics readers return `glyexp::GlycoproteomicSE`.
+
 # glyread 0.11.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,11 @@
 
 ## Breaking changes
 
-* All `read_*()` functions now return `glyexp::GlycomicSE` or `glyexp::GlycoproteomicSE` objects; code using legacy `glyexp::experiment()` fields must migrate to `SummarizedExperiment` assays, `rowData`, `colData`, and metadata. This is Stage II of glyexp#15.
+* All `read_*()` functions now return `glyexp::GlycomicSE` or `glyexp::GlycoproteomicSE` objects; code using legacy `glyexp::experiment()` fields must migrate to `SummarizedExperiment` assays, `rowData`, `colData`, and metadata. This is Stage II of glyexp#15. (#14)
 
 ## New features
 
-* `read_glyhunter()` now returns `glyexp::GlycomicSE`, while all glycoproteomics readers return `glyexp::GlycoproteomicSE`.
+* `read_glyhunter()` now returns `glyexp::GlycomicSE`, while all glycoproteomics readers return `glyexp::GlycoproteomicSE`. (#14)
 
 # glyread 0.11.0
 

--- a/R/byonic-byologic.R
+++ b/R/byonic-byologic.R
@@ -2,7 +2,7 @@
 #'
 #' If you used Byonic for intact glycopeptide identification,
 #' and used Byologic for quantification, this is the function for you.
-#' It reads in a result file and returns a [glyexp::experiment()] object.
+#' It reads in a result file and returns a [glyexp::GlycoproteomicSE()] object.
 #' Currently only label-free quantification is supported.
 #'
 #' @section Which file to use?:
@@ -36,8 +36,8 @@
 #'   - "expand" (default) expands each multisite glycopeptide into site-specific rows.
 #'   - "drop" removes multisite glycopeptides.
 #'
-#' @returns An [glyexp::experiment()] object.
-#' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()]
+#' @returns An [glyexp::GlycoproteomicSE()] object.
+#' @seealso [glyexp::GlycoproteomicSE()], [glyrepr::glycan_composition()]
 #' @export
 read_byonic_byologic <- function(
   fp,

--- a/R/byonic-pglycoquant.R
+++ b/R/byonic-pglycoquant.R
@@ -2,7 +2,7 @@
 #'
 #' If you used Byonic for intact glycopeptide identification,
 #' and used pGlycoQuant for quantification, this is the function for you.
-#' It reads in a pGlycoQuant result file and returns a [glyexp::experiment()] object.
+#' It reads in a pGlycoQuant result file and returns a [glyexp::GlycoproteomicSE()] object.
 #' Currently only label-free quantification is supported.
 #'
 #' @section Which file to use?:
@@ -33,8 +33,8 @@
 #' @inheritParams read_pglyco3_pglycoquant
 #' @inheritParams read_byonic_byologic
 #'
-#' @returns An [glyexp::experiment()] object.
-#' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()]
+#' @returns An [glyexp::GlycoproteomicSE()] object.
+#' @seealso [glyexp::GlycoproteomicSE()], [glyrepr::glycan_composition()]
 #' @export
 read_byonic_pglycoquant <- function(
   fp,

--- a/R/glycan-finder.R
+++ b/R/glycan-finder.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' GlycanFinder is a software for intact glycopeptide identification.
-#' This function reads in the result file and returns a [glyexp::experiment()] object.
+#' This function reads in the result file and returns a [glyexp::GlycoproteomicSE()] object.
 #' Currently only label-free quantification is supported.
 #'
 #' @section Which file to use?:
@@ -43,8 +43,8 @@
 #'  `var_info` as `glycan_structure` column. If `FALSE`, structure parsing
 #'  is skipped and structure-related columns are removed.
 #'
-#' @returns An [glyexp::experiment()] object.
-#' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()],
+#' @returns An [glyexp::GlycoproteomicSE()] object.
+#' @seealso [glyexp::GlycoproteomicSE()], [glyrepr::glycan_composition()],
 #'   [glyrepr::glycan_structure()]
 #' @export
 read_glycan_finder <- function(

--- a/R/glyco-decipher.R
+++ b/R/glyco-decipher.R
@@ -1,7 +1,7 @@
 #' Read glyco-decipher output
 #'
 #' Glyco-Decipher is a software for glycopeptide identification and quantification.
-#' This function reads in the result file and returns a [glyexp::experiment()] object.
+#' This function reads in the result file and returns a [glyexp::GlycoproteomicSE()] object.
 #' Currently only label-free quantification is supported.
 #'
 #' @section Which file to use?:
@@ -30,7 +30,7 @@
 #' @param orgdb name of the OrgDb package to use for UniProt to gene symbol conversion.
 #'  Default is "org.Hs.eg.db".
 #'
-#' @returns An [glyexp::experiment()] object.
+#' @returns An [glyexp::GlycoproteomicSE()] object.
 #' @export
 read_glyco_decipher <- function(
   fp,
@@ -56,12 +56,6 @@ read_glyco_decipher <- function(
     cli::cli_progress_step("Reading data")
     df <- .read_glyco_decipher_df(fp)
     tidy_df <- .tidy_glyco_decipher(df, orgdb)
-    # Add placeholder columns for standardize_variable() temporarily
-    tidy_df <- dplyr::mutate(
-      tidy_df,
-      peptide = "N", # Placeholder for N-glycosylation
-      peptide_site = 1L
-    )
     exp <- .read_template(
       tidy_df,
       sample_info,
@@ -72,8 +66,6 @@ read_glyco_decipher <- function(
       structure_parser = NULL,
       parse_structure = FALSE
     )
-    # Remove placeholder columns so they don't appear in final var_info
-    exp$var_info <- dplyr::select(exp$var_info, -"peptide", -"peptide_site")
   } else {
     rlang::abort("TMT quantification is not supported yet.")
   }

--- a/R/glyhunter.R
+++ b/R/glyhunter.R
@@ -1,7 +1,7 @@
 #' Read GlyHunter result
 #'
 #' This function reads in a [GlyHunter](https://github.com/fubin1999/glyhunter)
-#' result file and returns a [glyexp::experiment()] object.
+#' result file and returns a [glyexp::GlycomicSE()] object.
 #'
 #' @details
 #' # Which file to use?
@@ -26,8 +26,8 @@
 #'   Use "Fu_NC_2026" to use the configuration following "DOI: 10.1038/s41467-026-68579-x".
 #'   Use "Fu_NP_2026" to use the configuration in an unpublished Nature Protocols paper.
 #'
-#' @returns An [glyexp::experiment()] object.
-#' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()]
+#' @returns An [glyexp::GlycomicSE()] object.
+#' @seealso [glyexp::GlycomicSE()], [glyrepr::glycan_composition()]
 #' @export
 read_glyhunter <- function(
   fp,
@@ -80,7 +80,7 @@ read_glyhunter <- function(
 
   # Prepare sample info
   samples <- setdiff(colnames(df), "glycan")
-  sample_info <- .process_sample_info(sample_info, samples, glycan_type)
+  sample_info <- .process_sample_info(sample_info, samples)
 
   # Prepare variable info
   var_info <- df |>
@@ -102,14 +102,8 @@ read_glyhunter <- function(
     as.matrix()
   rownames(expr_mat) <- var_info$variable
 
-  # Pack experiment
-  glyexp::experiment(
-    expr_mat,
-    sample_info = sample_info,
-    var_info = var_info,
-    exp_type = "glycomics",
-    glycan_type = glycan_type
-  )
+  # Pack GlycomicSE
+  .new_glycomic_se(expr_mat, sample_info, var_info, glycan_type)
 }
 
 .read_glyhunter_np <- function(
@@ -129,7 +123,7 @@ read_glyhunter <- function(
 
   # Prepare sample info
   samples <- setdiff(colnames(df), "glycan")
-  sample_info <- .process_sample_info(sample_info, samples, glycan_type)
+  sample_info <- .process_sample_info(sample_info, samples)
 
   # Prepare variable info
   var_info <- df |>
@@ -165,12 +159,6 @@ read_glyhunter <- function(
     as.matrix()
   rownames(expr_mat) <- var_info$variable
 
-  # Pack experiment
-  glyexp::experiment(
-    expr_mat,
-    sample_info = sample_info,
-    var_info = var_info,
-    exp_type = "glycomics",
-    glycan_type = glycan_type
-  )
+  # Pack GlycomicSE
+  .new_glycomic_se(expr_mat, sample_info, var_info, glycan_type)
 }

--- a/R/msfragger.R
+++ b/R/msfragger.R
@@ -1,7 +1,7 @@
 #' Read MSFragger-Glyco result
 #'
 #' MSFragger-Glyco is a software for glycopeptide identification and quantification.
-#' This function reads in the result file and returns a [glyexp::experiment()] object.
+#' This function reads in the result file and returns a [glyexp::GlycoproteomicSE()] object.
 #'
 #' This function uses the "psm.tsv" file in each sample folder.
 #' Sample names are extracted from the file paths.
@@ -20,8 +20,8 @@
 #' @param dp The directory path of the MSFragger-Glyco result folder.
 #' @inheritParams read_pglyco3_pglycoquant
 #'
-#' @returns An [glyexp::experiment()] object.
-#' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()]
+#' @returns An [glyexp::GlycoproteomicSE()] object.
+#' @seealso [glyexp::GlycoproteomicSE()], [glyrepr::glycan_composition()]
 #' @export
 read_msfragger <- function(
   dp,

--- a/R/pglyco3-pglycoquant.R
+++ b/R/pglyco3-pglycoquant.R
@@ -2,7 +2,7 @@
 #'
 #' If you used pGlyco3 for intact glycopeptide identification,
 #' and used pGlycoQuant for quantification, this is the function for you.
-#' It reads in a pGlycoQuant result file and returns a [glyexp::experiment()] object.
+#' It reads in a pGlycoQuant result file and returns a [glyexp::GlycoproteomicSE()] object.
 #' Currently only label-free quantification is supported.
 #'
 #' @details
@@ -44,8 +44,8 @@
 #'  `var_info` as `glycan_structure` column. If `FALSE` (default), structure parsing
 #'  is skipped and structure-related columns are removed.
 #'
-#' @returns An [glyexp::experiment()] object.
-#' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()],
+#' @returns An [glyexp::GlycoproteomicSE()] object.
+#' @seealso [glyexp::GlycoproteomicSE()], [glyrepr::glycan_composition()],
 #'   [glyrepr::glycan_structure()]
 #' @export
 read_pglyco3_pglycoquant <- function(

--- a/R/pglyco3.R
+++ b/R/pglyco3.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' pGlyco3 is a software for intact glycopeptide identification and quantification.
-#' This function reads in the result file and returns a [glyexp::experiment()] object.
+#' This function reads in the result file and returns a [glyexp::GlycoproteomicSE()] object.
 #' Currently only label-free quantification is supported.
 #'
 #' Use this function if you only use pGlyco3.
@@ -80,8 +80,8 @@
 #'  `var_info` as `glycan_structure` column. If `FALSE` (default), structure parsing
 #'  is skipped and structure-related columns are removed.
 #'
-#' @returns An [glyexp::experiment()] object.
-#' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()],
+#' @returns An [glyexp::GlycoproteomicSE()] object.
+#' @seealso [glyexp::GlycoproteomicSE()], [glyrepr::glycan_composition()],
 #'   [glyrepr::glycan_structure()]
 #' @export
 read_pglyco3 <- function(

--- a/R/sample-info-utils.R
+++ b/R/sample-info-utils.R
@@ -21,6 +21,7 @@
     } # Otherwise, assume it's already a tibble.
 
     checkmate::assert_names(colnames(sample_info), must.include = "sample")
+    sample_info$sample <- as.character(sample_info$sample)
     checkmate::assert_character(
       sample_info$sample,
       any.missing = FALSE,

--- a/R/sample-info-utils.R
+++ b/R/sample-info-utils.R
@@ -6,6 +6,8 @@
 #' @returns A validated sample information tibble.
 #' @noRd
 .process_sample_info <- function(sample_info, samples) {
+  samples <- as.character(samples)
+
   if (is.null(sample_info)) {
     sample_info <- tibble::tibble(sample = samples)
     cli::cli_alert_info(
@@ -19,19 +21,19 @@
       # Convert data.frame to tibble
       sample_info <- tibble::as_tibble(sample_info)
     } # Otherwise, assume it's already a tibble.
+  }
 
-    checkmate::assert_names(colnames(sample_info), must.include = "sample")
-    sample_info$sample <- as.character(sample_info$sample)
-    checkmate::assert_character(
-      sample_info$sample,
-      any.missing = FALSE,
-      unique = TRUE
+  checkmate::assert_names(colnames(sample_info), must.include = "sample")
+  sample_info$sample <- as.character(sample_info$sample)
+  checkmate::assert_character(
+    sample_info$sample,
+    any.missing = FALSE,
+    unique = TRUE
+  )
+  if (!setequal(sample_info$sample, samples)) {
+    cli::cli_abort(
+      "Sample identifiers in {.arg sample_info} must match the input data."
     )
-    if (!setequal(sample_info$sample, samples)) {
-      cli::cli_abort(
-        "Sample identifiers in {.arg sample_info} must match the input data."
-      )
-    }
   }
 
   factor_cols <- intersect(

--- a/R/sample-info-utils.R
+++ b/R/sample-info-utils.R
@@ -1,6 +1,11 @@
-# Process sample information for read functions
-# This is a common utility function for all read_* functions
-.process_sample_info <- function(sample_info, samples, glycan_type) {
+#' Process sample information for read functions
+#'
+#' @param sample_info A file path, data frame, or `NULL`.
+#' @param samples The sample identifiers present in the input data.
+#'
+#' @returns A validated sample information tibble.
+#' @noRd
+.process_sample_info <- function(sample_info, samples) {
   if (is.null(sample_info)) {
     sample_info <- tibble::tibble(sample = samples)
     cli::cli_alert_info(
@@ -15,31 +20,24 @@
       sample_info <- tibble::as_tibble(sample_info)
     } # Otherwise, assume it's already a tibble.
 
-    # Validate sample_info format by creating a dummy experiment
-    # This passes the checking responsibility to `experiment()`.
-    local({
-      fake_var_info <- tibble::tibble(
-        variable = character(0),
-        protein = character(0),
-        protein_site = integer(0),
-        glycan_composition = glyrepr::glycan_composition(),
+    checkmate::assert_names(colnames(sample_info), must.include = "sample")
+    checkmate::assert_character(
+      sample_info$sample,
+      any.missing = FALSE,
+      unique = TRUE
+    )
+    if (!setequal(sample_info$sample, samples)) {
+      cli::cli_abort(
+        "Sample identifiers in {.arg sample_info} must match the input data."
       )
-      fake_expr_mat <- matrix(
-        nrow = 0,
-        ncol = length(samples),
-        dimnames = list(NULL, samples)
-      )
-
-      # This line will throw an error if sample_info is not in correct format.
-      glyexp::experiment(
-        fake_expr_mat,
-        sample_info,
-        fake_var_info,
-        exp_type = "glycoproteomics",
-        glycan_type = glycan_type
-      )
-    })
+    }
   }
+
+  factor_cols <- intersect(
+    c("group", "batch", "bio_rep"),
+    colnames(sample_info)
+  )
+  sample_info[factor_cols] <- purrr::map(sample_info[factor_cols], factor)
 
   sample_info
 }

--- a/R/strucgp.R
+++ b/R/strucgp.R
@@ -2,7 +2,7 @@
 #'
 #' StrucGP is a software for intact glycopeptide identification.
 #' As StrucGP doesn't support quantification,
-#' this function returns an [glyexp::experiment()] object with a binary (0/1) expression matrix
+#' this function returns an [glyexp::GlycoproteomicSE()] object with a binary (0/1) expression matrix
 #' indicating whether each glycopeptide was identified in each sample.
 #'
 #' @details
@@ -40,9 +40,9 @@
 #'  `var_info` as `glycan_structure` column. If `FALSE`, structure parsing
 #'  is skipped and the structure column is removed.
 #'
-#' @returns An [glyexp::experiment()] object with a binary (0/1) expression matrix,
+#' @returns An [glyexp::GlycoproteomicSE()] object with a binary (0/1) expression matrix,
 #'  where 1 indicates the glycopeptide was identified in that sample and 0 indicates it was not.
-#' @seealso [glyexp::experiment()], [glyrepr::glycan_composition()],
+#' @seealso [glyexp::GlycoproteomicSE()], [glyrepr::glycan_composition()],
 #'   [glyrepr::glycan_structure()]
 #' @export
 read_strucgp <- function(
@@ -69,7 +69,7 @@ read_strucgp <- function(
   samples <- unique(tidy_df$sample)
 
   # ----- Process sample information -----
-  sample_info <- .process_sample_info(sample_info, samples, glycan_type)
+  sample_info <- .process_sample_info(sample_info, samples)
 
   # ----- Create variable information -----
   cli::cli_progress_step("Creating variable information")
@@ -97,25 +97,15 @@ read_strucgp <- function(
     expr_mat[var_id, sample_id] <- 1
   }
 
-  # ----- Pack experiment -----
-  cli::cli_progress_step("Creating experiment object")
-  exp <- glyexp::experiment(
+  # ----- Pack GlycoproteomicSE -----
+  cli::cli_progress_step("Creating GlycoproteomicSE object")
+  .new_glycoproteomic_se(
     expr_mat,
     sample_info,
     var_info,
-    exp_type = "glycoproteomics",
     glycan_type = glycan_type,
     quant_method = "label-free"
   )
-
-  # ----- Standardize variable IDs -----
-  # standardize_variable returns a modified copy
-  exp <- glyexp::standardize_variable(exp)
-
-  # Remove placeholder columns so they don't appear in final var_info
-  exp$var_info <- dplyr::select(exp$var_info, -"peptide", -"peptide_site")
-
-  exp
 }
 
 .tidy_strucgp <- function(df, parse_structure) {
@@ -155,14 +145,6 @@ read_strucgp <- function(
     gene = protein_vectors$gene,
     protein_site = as.integer(protein_vectors$protein_site)
   )
-
-  # Add peptide and peptide_site for standardize_variable()
-  # StrucGP only works with N-glycans, so use "N" as placeholder
-  result <- result %>%
-    dplyr::mutate(
-      peptide = "N", # Placeholder for N-glycosylation
-      peptide_site = 1L
-    )
 
   # Parse structure only if requested
   if (parse_structure) {

--- a/R/template.R
+++ b/R/template.R
@@ -93,14 +93,17 @@
   var_info$variable <- .standardize_glycoproteomic_variables(var_info)
   rownames(expr_mat) <- var_info$variable
 
-  glyexp::GlycoproteomicSE(
+  .muffle_all_missing_assay_warning(
     expr_mat,
-    colData = .as_se_data(sample_info, "sample"),
-    rowData = .as_se_data(var_info, "variable"),
-    metadata = list(
-      exp_type = "glycoproteomics",
-      glycan_type = glycan_type,
-      quant_method = quant_method
+    glyexp::GlycoproteomicSE(
+      expr_mat,
+      colData = .as_se_data(sample_info, "sample"),
+      rowData = .as_se_data(var_info, "variable"),
+      metadata = list(
+        exp_type = "glycoproteomics",
+        glycan_type = glycan_type,
+        quant_method = quant_method
+      )
     )
   )
 }
@@ -114,14 +117,45 @@
 .new_glycomic_se <- function(expr_mat, sample_info, var_info, glycan_type) {
   ids <- .prepare_se_ids(expr_mat, sample_info, var_info)
 
-  glyexp::GlycomicSE(
+  .muffle_all_missing_assay_warning(
     ids$expr_mat,
-    colData = .as_se_data(ids$sample_info, "sample"),
-    rowData = .as_se_data(ids$var_info, "variable"),
-    metadata = list(
-      exp_type = "glycomics",
-      glycan_type = glycan_type
+    glyexp::GlycomicSE(
+      ids$expr_mat,
+      colData = .as_se_data(ids$sample_info, "sample"),
+      rowData = .as_se_data(ids$var_info, "variable"),
+      metadata = list(
+        exp_type = "glycomics",
+        glycan_type = glycan_type
+      )
     )
+  )
+}
+
+#' Muffle the empty-min warning for an all-missing assay
+#'
+#' The glyco SE validity methods use `min(..., na.rm = TRUE)` to reject
+#' negative abundance. Base R warns when the assay contains no non-missing
+#' values, even though such an assay is valid.
+#'
+#' @param abundance A numeric abundance matrix.
+#' @param code Code that constructs a glyco SE object.
+#'
+#' @returns The result of `code`.
+#' @noRd
+.muffle_all_missing_assay_warning <- function(abundance, code) {
+  all_missing <- all(is.na(abundance))
+
+  withCallingHandlers(
+    code,
+    warning = function(cnd) {
+      is_empty_min_warning <- startsWith(
+        conditionMessage(cnd),
+        "no non-missing arguments to min"
+      )
+      if (all_missing && is_empty_min_warning) {
+        rlang::cnd_muffle(cnd)
+      }
+    }
   )
 }
 

--- a/R/template.R
+++ b/R/template.R
@@ -4,7 +4,7 @@
 # 3. Process sample information
 # 4. Extracting variable information and expression matrix
 # 5. Parse glycan compositions and structures
-# 6. Packing an experiment
+# 6. Packing a GlycoproteomicSE
 #
 # `tidy_df` should be a long-format tibble with the following columns:
 # "sample", "value", and all other columns being variable information.
@@ -31,7 +31,7 @@
 
   # ----- 3. Process sample information -----
   samples <- unique(tidy_df$sample)
-  sample_info <- .process_sample_info(sample_info_arg, samples, glycan_type)
+  sample_info <- .process_sample_info(sample_info_arg, samples)
 
   # ----- 4. Extracting variable information and expression matrix -----
   wide_df <- tidy_df %>%
@@ -58,17 +58,152 @@
     var_info <- dplyr::select(var_info, -any_of("glycan_structure"))
   }
 
-  # ----- 6. Packing Experiment -----
-  exp <- glyexp::experiment(
+  # ----- 6. Pack GlycoproteomicSE -----
+  .new_glycoproteomic_se(
     expr_mat,
     sample_info,
     var_info,
-    exp_type = "glycoproteomics",
     glycan_type = glycan_type,
     quant_method = quant_method
   )
+}
 
-  # ----- 7. Standardize variable IDs -----
-  # standardize_variable returns a modified copy
-  glyexp::standardize_variable(exp)
+#' Create a GlycoproteomicSE from reader output
+#'
+#' @param expr_mat A numeric abundance matrix.
+#' @param sample_info A sample information data frame with a `sample` column.
+#' @param var_info A variable information data frame with a `variable` column.
+#' @param glycan_type The glycan type.
+#' @param quant_method The quantification method.
+#'
+#' @returns A [glyexp::GlycoproteomicSE()] object.
+#' @noRd
+.new_glycoproteomic_se <- function(
+  expr_mat,
+  sample_info,
+  var_info,
+  glycan_type,
+  quant_method
+) {
+  ids <- .prepare_se_ids(expr_mat, sample_info, var_info)
+  expr_mat <- ids$expr_mat
+  sample_info <- ids$sample_info
+  var_info <- ids$var_info
+
+  var_info$variable <- .standardize_glycoproteomic_variables(var_info)
+  rownames(expr_mat) <- var_info$variable
+
+  glyexp::GlycoproteomicSE(
+    expr_mat,
+    colData = .as_se_data(sample_info, "sample"),
+    rowData = .as_se_data(var_info, "variable"),
+    metadata = list(
+      exp_type = "glycoproteomics",
+      glycan_type = glycan_type,
+      quant_method = quant_method
+    )
+  )
+}
+
+#' Create a GlycomicSE from reader output
+#'
+#' @inheritParams .new_glycoproteomic_se
+#'
+#' @returns A [glyexp::GlycomicSE()] object.
+#' @noRd
+.new_glycomic_se <- function(expr_mat, sample_info, var_info, glycan_type) {
+  ids <- .prepare_se_ids(expr_mat, sample_info, var_info)
+
+  glyexp::GlycomicSE(
+    ids$expr_mat,
+    colData = .as_se_data(ids$sample_info, "sample"),
+    rowData = .as_se_data(ids$var_info, "variable"),
+    metadata = list(
+      exp_type = "glycomics",
+      glycan_type = glycan_type
+    )
+  )
+}
+
+#' Validate and align assay and dimension metadata identifiers
+#'
+#' @inheritParams .new_glycoproteomic_se
+#'
+#' @returns A list containing the aligned assay, sample information, and
+#'   variable information.
+#' @noRd
+.prepare_se_ids <- function(expr_mat, sample_info, var_info) {
+  checkmate::assert_names(colnames(sample_info), must.include = "sample")
+  checkmate::assert_names(colnames(var_info), must.include = "variable")
+  checkmate::assert_character(
+    sample_info$sample,
+    any.missing = FALSE,
+    unique = TRUE
+  )
+  checkmate::assert_character(
+    var_info$variable,
+    any.missing = FALSE,
+    unique = TRUE
+  )
+
+  if (!setequal(colnames(expr_mat), sample_info$sample)) {
+    cli::cli_abort(
+      "Sample identifiers in {.arg sample_info} must match assay column names."
+    )
+  }
+  if (!setequal(rownames(expr_mat), var_info$variable)) {
+    cli::cli_abort(
+      "Variable identifiers in {.arg var_info} must match assay row names."
+    )
+  }
+
+  list(
+    expr_mat = expr_mat[var_info$variable, sample_info$sample, drop = FALSE],
+    sample_info = sample_info,
+    var_info = var_info
+  )
+}
+
+#' Convert identifier-bearing metadata to an S4 DataFrame
+#'
+#' @param x A data frame.
+#' @param id_col The identifier column to move to row names.
+#'
+#' @returns An [S4Vectors::DataFrame()] without the identifier column.
+#' @noRd
+.as_se_data <- function(x, id_col) {
+  ids <- x[[id_col]]
+  x[[id_col]] <- NULL
+  S4Vectors::DataFrame(x, row.names = ids)
+}
+
+#' Standardize glycoproteomics variable identifiers
+#'
+#' @param var_info A variable information data frame.
+#'
+#' @returns A unique character vector of variable identifiers.
+#' @noRd
+.standardize_glycoproteomic_variables <- function(var_info) {
+  variables <- paste(
+    var_info$protein,
+    dplyr::if_else(
+      is.na(var_info$protein_site),
+      "X",
+      as.character(var_info$protein_site)
+    ),
+    as.character(var_info$glycan_composition),
+    sep = "-"
+  )
+
+  tibble::tibble(variable = variables) |>
+    dplyr::group_by(.data$variable) |>
+    dplyr::mutate(
+      variable = if (dplyr::n() > 1L) {
+        paste0(.data$variable, "-", dplyr::row_number())
+      } else {
+        .data$variable
+      }
+    ) |>
+    dplyr::ungroup() |>
+    dplyr::pull(.data$variable)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,7 +24,8 @@ knitr::opts_chunk$set(
 
 The goal of glyread is to read and process quantification results from
 common glycomics and glycoproteomics software, such as Byonic, StrucGP,
-or pGlyco, and convert them into a `glyexp::expriment()` object 
+or pGlyco, and convert them into `glyexp::GlycomicSE` or
+`glyexp::GlycoproteomicSE` objects
 (from the [glyexp](https://github.com/glycoverse/glyexp) package)
 for further analysis.
 
@@ -72,7 +73,8 @@ are also applicable here: [Installation of glycoverse](https://github.com/glycov
 `glyread` is the entry point for the `glycoverse` ecosystem.
 It provides a unified interface for reading and processing data from
 various glycomics and glycoproteomics software, and converting them
-into a `glyexp::experiment()` object for further analysis.
+into `glyexp::GlycomicSE` or `glyexp::GlycoproteomicSE` objects for further
+analysis.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ coverage](https://codecov.io/gh/glycoverse/glyread/graph/badge.svg)](https://app
 
 The goal of glyread is to read and process quantification results from
 common glycomics and glycoproteomics software, such as Byonic, StrucGP,
-or pGlyco, and convert them into a `glyexp::expriment()` object (from
-the [glyexp](https://github.com/glycoverse/glyexp) package) for further
+or pGlyco, and convert them into `glyexp::GlycomicSE` or
+`glyexp::GlycoproteomicSE` objects (from the
+[glyexp](https://github.com/glycoverse/glyexp) package) for further
 analysis.
 
 ## Installation
@@ -71,8 +72,9 @@ glycoverse](https://github.com/glycoverse/glycoverse#installation).
 
 `glyread` is the entry point for the `glycoverse` ecosystem. It provides
 a unified interface for reading and processing data from various
-glycomics and glycoproteomics software, and converting them into a
-`glyexp::experiment()` object for further analysis.
+glycomics and glycoproteomics software, and converting them into
+`glyexp::GlycomicSE` or `glyexp::GlycoproteomicSE` objects for further
+analysis.
 
 ## Example
 

--- a/man/glyread-package.Rd
+++ b/man/glyread-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Provides a unified interface for reading and processing quantification results from various glycomics and glycoproteomics software tools, including Byonic (ByoLogic, pGlycoQuant), StrucGP, pGlyco3 (pGlycoQuant), Glyco-Decipher, GlyHunter, and MSFragger. The package standardizes raw data from different sources, performs peptide-spectrum match (PSM) aggregation, parses glycan compositions and structures, and converts the data into a standardized experiment object from the 'glyexp' package for downstream analysis within the glycoverse ecosystem.
+Provides a unified interface for reading and processing quantification results from various glycomics and glycoproteomics software tools, including Byonic (ByoLogic, pGlycoQuant), StrucGP, pGlyco3 (pGlycoQuant), Glyco-Decipher, GlyHunter, and MSFragger. The package standardizes raw data from different sources, performs peptide-spectrum match (PSM) aggregation, parses glycan compositions and structures, and converts the data into a standardized 'GlycomicSE' and 'GlycoproteomicSE' objects from the 'glyexp' package for downstream analysis within the glycoverse ecosystem.
 }
 \seealso{
 Useful links:

--- a/man/read_byonic_byologic.Rd
+++ b/man/read_byonic_byologic.Rd
@@ -41,12 +41,12 @@ Default is "org.Hs.eg.db".}
 }}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+An \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 }
 \description{
 If you used Byonic for intact glycopeptide identification,
 and used Byologic for quantification, this is the function for you.
-It reads in a result file and returns a \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+It reads in a result file and returns a \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 Currently only label-free quantification is supported.
 }
 \section{Which file to use?}{
@@ -103,5 +103,5 @@ we sum up the quantifications of all PSMs that belong to this glycopeptide.
 }
 
 \seealso{
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}
 }

--- a/man/read_byonic_pglycoquant.Rd
+++ b/man/read_byonic_pglycoquant.Rd
@@ -47,12 +47,12 @@ is skipped and structure-related columns are removed.}
 }}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+An \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 }
 \description{
 If you used Byonic for intact glycopeptide identification,
 and used pGlycoQuant for quantification, this is the function for you.
-It reads in a pGlycoQuant result file and returns a \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+It reads in a pGlycoQuant result file and returns a \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 Currently only label-free quantification is supported.
 }
 \section{Which file to use?}{
@@ -110,5 +110,5 @@ we sum up the quantifications of all PSMs that belong to this glycopeptide.
 }
 
 \seealso{
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}
 }

--- a/man/read_glycan_finder.Rd
+++ b/man/read_glycan_finder.Rd
@@ -40,11 +40,11 @@ If \code{TRUE} (default), glycan structures are parsed and included in the
 is skipped and structure-related columns are removed.}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+An \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 }
 \description{
 GlycanFinder is a software for intact glycopeptide identification.
-This function reads in the result file and returns a \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+This function reads in the result file and returns a \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 Currently only label-free quantification is supported.
 }
 \section{Which file to use?}{
@@ -76,6 +76,6 @@ The following columns could be found in the variable information tibble:
 }
 
 \seealso{
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}},
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}},
 \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}
 }

--- a/man/read_glyco_decipher.Rd
+++ b/man/read_glyco_decipher.Rd
@@ -34,11 +34,11 @@ If NULL, original names are kept.}
 Default is "org.Hs.eg.db".}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+An \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 }
 \description{
 Glyco-Decipher is a software for glycopeptide identification and quantification.
-This function reads in the result file and returns a \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+This function reads in the result file and returns a \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 Currently only label-free quantification is supported.
 }
 \section{Which file to use?}{

--- a/man/read_glyhunter.Rd
+++ b/man/read_glyhunter.Rd
@@ -32,11 +32,11 @@ Note that sample names in \code{sample_info} should match the new names.
 If NULL, original names are kept.}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+An \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} object.
 }
 \description{
 This function reads in a \href{https://github.com/fubin1999/glyhunter}{GlyHunter}
-result file and returns a \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+result file and returns a \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} object.
 }
 \section{Which file to use?}{
 Use the "summary_area.csv" file in the GlyHunter result folder.
@@ -72,5 +72,5 @@ required for most downstream analyses
 }
 
 \seealso{
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}
+\code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}
 }

--- a/man/read_msfragger.Rd
+++ b/man/read_msfragger.Rd
@@ -30,11 +30,11 @@ Note that sample names in \code{sample_info} should match the new names.
 If NULL, original names are kept.}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+An \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 }
 \description{
 MSFragger-Glyco is a software for glycopeptide identification and quantification.
-This function reads in the result file and returns a \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+This function reads in the result file and returns a \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 }
 \details{
 This function uses the "psm.tsv" file in each sample folder.
@@ -56,5 +56,5 @@ The following columns could be found in the variable information tibble:
 }
 
 \seealso{
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}}
 }

--- a/man/read_pglyco3.Rd
+++ b/man/read_pglyco3.Rd
@@ -36,11 +36,11 @@ If \code{TRUE}, glycan structures are parsed and included in the
 is skipped and structure-related columns are removed.}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+An \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 }
 \description{
 pGlyco3 is a software for intact glycopeptide identification and quantification.
-This function reads in the result file and returns a \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+This function reads in the result file and returns a \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 Currently only label-free quantification is supported.
 
 Use this function if you only use pGlyco3.
@@ -106,6 +106,6 @@ because pGlyco3 does not have strict quality control on glycan structure annotat
 }
 
 \seealso{
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}},
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}},
 \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}
 }

--- a/man/read_pglyco3_pglycoquant.Rd
+++ b/man/read_pglyco3_pglycoquant.Rd
@@ -36,12 +36,12 @@ If \code{TRUE}, glycan structures are parsed and included in the
 is skipped and structure-related columns are removed.}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+An \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 }
 \description{
 If you used pGlyco3 for intact glycopeptide identification,
 and used pGlycoQuant for quantification, this is the function for you.
-It reads in a pGlycoQuant result file and returns a \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+It reads in a pGlycoQuant result file and returns a \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object.
 Currently only label-free quantification is supported.
 }
 \section{Which file to use?}{
@@ -106,6 +106,6 @@ because pGlyco3 does not have strict quality control on glycan structure annotat
 }
 
 \seealso{
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}},
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}},
 \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}
 }

--- a/man/read_strucgp.Rd
+++ b/man/read_strucgp.Rd
@@ -22,13 +22,13 @@ If \code{TRUE} (default), glycan structures are parsed and included in the
 is skipped and the structure column is removed.}
 }
 \value{
-An \code{\link[glyexp:experiment]{glyexp::experiment()}} object with a binary (0/1) expression matrix,
+An \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object with a binary (0/1) expression matrix,
 where 1 indicates the glycopeptide was identified in that sample and 0 indicates it was not.
 }
 \description{
 StrucGP is a software for intact glycopeptide identification.
 As StrucGP doesn't support quantification,
-this function returns an \code{\link[glyexp:experiment]{glyexp::experiment()}} object with a binary (0/1) expression matrix
+this function returns an \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object with a binary (0/1) expression matrix
 indicating whether each glycopeptide was identified in each sample.
 }
 \section{Variable information}{
@@ -59,6 +59,6 @@ required for most downstream analyses
 }
 
 \seealso{
-\code{\link[glyexp:experiment]{glyexp::experiment()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}},
+\code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}}, \code{\link[glyrepr:glycan_composition]{glyrepr::glycan_composition()}},
 \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}
 }

--- a/tests/testthat/helper-se.R
+++ b/tests/testthat/helper-se.R
@@ -1,0 +1,21 @@
+.test_expr_mat <- function(x) {
+  SummarizedExperiment::assay(x, "abundance")
+}
+
+.test_var_info <- function(x) {
+  tibble::as_tibble(
+    SummarizedExperiment::rowData(x),
+    rownames = "variable"
+  )
+}
+
+.test_sample_info <- function(x) {
+  tibble::as_tibble(
+    SummarizedExperiment::colData(x),
+    rownames = "sample"
+  )
+}
+
+.test_metadata <- function(x) {
+  S4Vectors::metadata(x)
+}

--- a/tests/testthat/test-byonic-byologic.R
+++ b/tests/testthat/test-byonic-byologic.R
@@ -16,26 +16,26 @@ test_that("it returns correct information (label-free)", {
     "glycan_composition",
     "peptide_site"
   )
-  expect_true(all(expected_cols %in% colnames(res$var_info)))
+  expect_true(all(expected_cols %in% colnames(.test_var_info(res))))
 
   # Gene column is optional (requires org.Hs.eg.db)
-  if ("gene" %in% colnames(res$var_info)) {
-    expect_type(res$var_info$gene, "character")
+  if ("gene" %in% colnames(.test_var_info(res))) {
+    expect_type(.test_var_info(res)$gene, "character")
   }
 
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
-  expect_equal(colnames(res$sample_info), c("sample"))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
+  expect_equal(colnames(.test_sample_info(res)), c("sample"))
   expect_true(all(
     c(
       "20241224-LXJ-Nglyco-H_1",
       "20241224-LXJ-Nglyco-H_2",
       "20241224-LXJ-Nglyco-H_3"
     ) %in%
-      colnames(res$expr_mat)
+      colnames(.test_expr_mat(res))
   ))
-  expect_equal(rownames(res$expr_mat), res$var_info$variable)
+  expect_equal(rownames(.test_expr_mat(res)), .test_var_info(res)$variable)
   expect_equal(
-    res$meta_data,
+    .test_metadata(res),
     list(
       exp_type = "glycoproteomics",
       glycan_type = "N",
@@ -55,16 +55,16 @@ test_that("multisite glycopeptides are handled correctly in full workflow", {
   )
 
   # All entries should be present (multisite glycopeptides are no longer filtered out)
-  expect_true(nrow(res$var_info) > 0)
+  expect_true(nrow(.test_var_info(res)) > 0)
 
   # Multisite glycopeptides should be expanded before composition parsing,
   # so parsed output should not retain comma-separated compositions.
-  compositions <- as.character(res$var_info$glycan_composition)
+  compositions <- as.character(.test_var_info(res)$glycan_composition)
   multisite_entries <- stringr::str_detect(compositions, ",")
   expect_false(any(multisite_entries))
 
   # Expanded entries should have valid protein_site values.
-  expect_true(all(!is.na(res$var_info$protein_site)))
+  expect_true(all(!is.na(.test_var_info(res)$protein_site)))
 })
 
 
@@ -92,18 +92,18 @@ test_that("multisite glycopeptides are expanded into site-specific rows", {
     )
   )
 
-  res$var_info <- dplyr::arrange(res$var_info, .data$protein_site)
+  var_info <- dplyr::arrange(.test_var_info(res), .data$protein_site)
 
-  expect_equal(nrow(res$var_info), 2L)
-  expect_false("gp_id" %in% colnames(res$var_info))
-  expect_equal(res$var_info$peptide_site, c(5L, 9L))
-  expect_equal(res$var_info$protein_site, c(14L, 18L))
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_equal(nrow(var_info), 2L)
+  expect_false("gp_id" %in% colnames(var_info))
+  expect_equal(var_info$peptide_site, c(5L, 9L))
+  expect_equal(var_info$protein_site, c(14L, 18L))
+  expect_s3_class(var_info$glycan_composition, "glyrepr_composition")
   expect_equal(
-    as.character(res$var_info$glycan_composition),
+    as.character(var_info$glycan_composition),
     c("HexNAc(1)dHex(1)", "Hex(5)HexNAc(4)dHex(1)NeuAc(1)")
   )
-  expect_equal(as.numeric(res$expr_mat[, "Sample1"]), c(100, 100))
+  expect_equal(as.numeric(.test_expr_mat(res)[, "Sample1"]), c(100, 100))
 })
 
 test_that("multisite glycopeptides can be dropped", {
@@ -137,14 +137,14 @@ test_that("multisite glycopeptides can be dropped", {
     )
   )
 
-  expect_equal(nrow(res$var_info), 1L)
-  expect_equal(res$var_info$peptide_site, 5L)
-  expect_equal(res$var_info$protein_site, 14L)
+  expect_equal(nrow(.test_var_info(res)), 1L)
+  expect_equal(.test_var_info(res)$peptide_site, 5L)
+  expect_equal(.test_var_info(res)$protein_site, 14L)
   expect_equal(
-    as.character(res$var_info$glycan_composition),
+    as.character(.test_var_info(res)$glycan_composition),
     "HexNAc(1)dHex(1)"
   )
-  expect_equal(as.numeric(res$expr_mat[, "Sample1"]), 50)
+  expect_equal(as.numeric(.test_expr_mat(res)[, "Sample1"]), 50)
 })
 
 
@@ -158,12 +158,12 @@ test_that("hierarchical rows are correctly collapsed", {
   )
 
   # Check that we have multiple samples in the expression matrix
-  expect_true(ncol(res$expr_mat) > 1) # Multiple samples
+  expect_true(ncol(.test_expr_mat(res)) > 1) # Multiple samples
 
   # Check that each variable appears only once (no duplicates in var_info)
   expect_equal(
-    length(res$var_info$variable),
-    length(unique(res$var_info$variable))
+    length(.test_var_info(res)$variable),
+    length(unique(.test_var_info(res)$variable))
   )
 })
 
@@ -178,7 +178,7 @@ test_that("protein accessions are correctly extracted", {
   )
 
   # Check protein extraction from UniProt format
-  proteins <- res$var_info$protein
+  proteins <- .test_var_info(res)$protein
   expect_true(all(nchar(proteins) > 0))
 
   # Check some specific examples we know should be in the data (only glycosylated proteins)
@@ -196,7 +196,7 @@ test_that("glycan compositions are correctly processed and parsed", {
     )
   )
 
-  compositions <- res$var_info$glycan_composition
+  compositions <- .test_var_info(res)$glycan_composition
   expect_s3_class(compositions, "glyrepr_composition")
 
   # Check that Fuc is converted to dHex
@@ -220,7 +220,7 @@ test_that("peptides are correctly processed", {
     )
   )
 
-  peptides <- res$var_info$peptide
+  peptides <- .test_var_info(res)$peptide
 
   # Check that peptides are uppercase
   expect_true(all(peptides == stringr::str_to_upper(peptides)))
@@ -243,17 +243,19 @@ test_that("peptide and protein sites are correctly calculated", {
   )
 
   # Check that peptide_site is integer and reasonable
-  expect_type(res$var_info$peptide_site, "integer")
-  expect_true(all(res$var_info$peptide_site > 0))
-  expect_true(all(res$var_info$peptide_site <= 50)) # Reasonable range for peptide sites
+  expect_type(.test_var_info(res)$peptide_site, "integer")
+  expect_true(all(.test_var_info(res)$peptide_site > 0))
+  expect_true(all(.test_var_info(res)$peptide_site <= 50)) # Reasonable range for peptide sites
 
   # Check that protein_site is integer and reasonable
-  expect_type(res$var_info$protein_site, "integer")
-  expect_true(all(res$var_info$protein_site > 0))
-  expect_true(all(res$var_info$protein_site <= 1000)) # Reasonable range for protein sites
+  expect_type(.test_var_info(res)$protein_site, "integer")
+  expect_true(all(.test_var_info(res)$protein_site > 0))
+  expect_true(all(.test_var_info(res)$protein_site <= 1000)) # Reasonable range for protein sites
 
   # Check that protein_site >= peptide_site (since protein_site = start_aa + peptide_site - 1)
-  expect_true(all(res$var_info$protein_site >= res$var_info$peptide_site))
+  expect_true(all(
+    .test_var_info(res)$protein_site >= .test_var_info(res)$peptide_site
+  ))
 })
 
 
@@ -266,7 +268,7 @@ test_that("variables are correctly named with meaningful IDs", {
     )
   )
 
-  variables <- res$var_info$variable
+  variables <- .test_var_info(res)$variable
   # Variables should be meaningful: protein-site-glycan pattern
   expect_true(all(stringr::str_detect(variables, ".+?-\\d+-.+")))
   # And contain glycan composition info
@@ -285,7 +287,7 @@ test_that("intensity values are correctly processed", {
     )
   )
 
-  expr_mat <- res$expr_mat
+  expr_mat <- .test_expr_mat(res)
 
   # Check that zero values are converted to NA
   expect_true(all(is.na(expr_mat) | expr_mat > 0))
@@ -294,8 +296,8 @@ test_that("intensity values are correctly processed", {
   expect_true(is.numeric(expr_mat))
 
   # Check dimensions
-  expect_equal(nrow(expr_mat), nrow(res$var_info))
-  expect_equal(ncol(expr_mat), nrow(res$sample_info))
+  expect_equal(nrow(expr_mat), nrow(.test_var_info(res)))
+  expect_equal(ncol(expr_mat), nrow(.test_sample_info(res)))
 })
 
 
@@ -314,8 +316,8 @@ test_that("sample names are correctly extracted from MS alias names", {
     "20241224-LXJ-Nglyco-H_2",
     "20241224-LXJ-Nglyco-H_3"
   )
-  expect_true(all(expected_samples %in% res$sample_info$sample))
-  expect_true(all(expected_samples %in% colnames(res$expr_mat)))
+  expect_true(all(expected_samples %in% .test_sample_info(res)$sample))
+  expect_true(all(expected_samples %in% colnames(.test_expr_mat(res))))
 })
 
 
@@ -339,7 +341,7 @@ test_that("it handles O-linked glycan type", {
       glycan_type = "O-GalNAc"
     )
   )
-  expect_equal(res$meta_data$glycan_type, "O-GalNAc")
+  expect_equal(.test_metadata(res)$glycan_type, "O-GalNAc")
 })
 
 
@@ -353,12 +355,12 @@ test_that("all output data types are consistent", {
   )
 
   # Check that var_info has correct types
-  expect_type(res$var_info$variable, "character")
-  expect_type(res$var_info$peptide, "character")
-  expect_type(res$var_info$protein, "character")
-  expect_type(res$var_info$peptide_site, "integer")
-  expect_type(res$var_info$protein_site, "integer")
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_type(.test_var_info(res)$variable, "character")
+  expect_type(.test_var_info(res)$peptide, "character")
+  expect_type(.test_var_info(res)$protein, "character")
+  expect_type(.test_var_info(res)$peptide_site, "integer")
+  expect_type(.test_var_info(res)$protein_site, "integer")
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
 })
 
 
@@ -377,8 +379,8 @@ test_that("sample name converter works", {
   )
 
   expected_samples <- c("Sample_1", "Sample_2", "Sample_3")
-  expect_true(all(expected_samples %in% colnames(res$expr_mat)))
-  expect_true(all(expected_samples %in% res$sample_info$sample))
+  expect_true(all(expected_samples %in% colnames(.test_expr_mat(res))))
+  expect_true(all(expected_samples %in% .test_sample_info(res)$sample))
 })
 
 
@@ -429,8 +431,8 @@ test_that("it provides a default sample information tibble (label-free)", {
     "20241224-LXJ-Nglyco-H_2",
     "20241224-LXJ-Nglyco-H_3"
   )
-  expect_true(all(expected_samples %in% res$sample_info$sample))
-  expect_equal(colnames(res$sample_info), c("sample"))
+  expect_true(all(expected_samples %in% .test_sample_info(res)$sample))
+  expect_equal(colnames(.test_sample_info(res)), c("sample"))
 })
 
 
@@ -452,8 +454,8 @@ test_that("it accepts a sample_info tibble", {
     )
   )
 
-  expect_equal(colnames(res$sample_info), c("sample", "group"))
-  expect_equal(res$sample_info$group, factor(c("A", "B", "C")))
+  expect_equal(colnames(.test_sample_info(res)), c("sample", "group"))
+  expect_equal(.test_sample_info(res)$group, factor(c("A", "B", "C")))
 })
 
 
@@ -483,8 +485,10 @@ test_that("only glycosylated peptides are included", {
   )
 
   # All entries should have glycan compositions (no NA values)
-  expect_false(any(is.na(res$var_info$glycan_composition)))
-  expect_true(all(nchar(as.character(res$var_info$glycan_composition)) > 0))
+  expect_false(any(is.na(.test_var_info(res)$glycan_composition)))
+  expect_true(all(
+    nchar(as.character(.test_var_info(res)$glycan_composition)) > 0
+  ))
 })
 
 
@@ -499,5 +503,5 @@ test_that("it accepts custom orgdb parameter", {
   )
 
   # Should still work even if the orgdb is not available
-  expect_s3_class(res, "glyexp_experiment")
+  expect_s4_class(res, "GlycoproteomicSE")
 })

--- a/tests/testthat/test-byonic-pglycoquant.R
+++ b/tests/testthat/test-byonic-pglycoquant.R
@@ -16,19 +16,19 @@ test_that("it returns correct information (label-free)", {
     "glycan_composition",
     "peptide_site"
   )
-  expect_true(all(expected_cols %in% colnames(res$var_info)))
+  expect_true(all(expected_cols %in% colnames(.test_var_info(res))))
 
   # Gene column is optional (requires clusterProfiler and org.Hs.eg.db)
-  if ("gene" %in% colnames(res$var_info)) {
-    expect_type(res$var_info$gene, "character")
+  if ("gene" %in% colnames(.test_var_info(res))) {
+    expect_type(.test_var_info(res)$gene, "character")
   }
 
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
-  expect_equal(colnames(res$sample_info), c("sample"))
-  expect_equal(colnames(res$expr_mat), c("20241224-lxj-nglyco-h_1"))
-  expect_equal(rownames(res$expr_mat), res$var_info$variable)
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
+  expect_equal(colnames(.test_sample_info(res)), c("sample"))
+  expect_equal(colnames(.test_expr_mat(res)), c("20241224-lxj-nglyco-h_1"))
+  expect_equal(rownames(.test_expr_mat(res)), .test_var_info(res)$variable)
   expect_equal(
-    res$meta_data,
+    .test_metadata(res),
     list(
       exp_type = "glycoproteomics",
       glycan_type = "N",
@@ -47,16 +47,16 @@ test_that("multisite glycopeptides are handled correctly in full workflow", {
   )
 
   # All entries should be present (multisite glycopeptides are no longer filtered out)
-  expect_true(nrow(res$var_info) > 0)
+  expect_true(nrow(.test_var_info(res)) > 0)
 
   # Multisite glycopeptides should be expanded before composition parsing,
   # so parsed output should not retain comma-separated compositions.
-  compositions <- as.character(res$var_info$glycan_composition)
+  compositions <- as.character(.test_var_info(res)$glycan_composition)
   multisite_entries <- stringr::str_detect(compositions, ",")
   expect_false(any(multisite_entries))
 
   # Expanded entries should have valid protein_site values.
-  expect_true(all(!is.na(res$var_info$protein_site)))
+  expect_true(all(!is.na(.test_var_info(res)$protein_site)))
 })
 
 test_that("multisite Byonic-pGlycoQuant glycopeptides are expanded into site-specific rows", {
@@ -80,18 +80,18 @@ test_that("multisite Byonic-pGlycoQuant glycopeptides are expanded into site-spe
     )
   )
 
-  res$var_info <- dplyr::arrange(res$var_info, .data$protein_site)
+  var_info <- dplyr::arrange(.test_var_info(res), .data$protein_site)
 
-  expect_equal(nrow(res$var_info), 2L)
-  expect_false("gp_id" %in% colnames(res$var_info))
-  expect_equal(res$var_info$peptide_site, c(5L, 9L))
-  expect_equal(res$var_info$protein_site, c(239L, 243L))
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_equal(nrow(var_info), 2L)
+  expect_false("gp_id" %in% colnames(var_info))
+  expect_equal(var_info$peptide_site, c(5L, 9L))
+  expect_equal(var_info$protein_site, c(239L, 243L))
+  expect_s3_class(var_info$glycan_composition, "glyrepr_composition")
   expect_equal(
-    as.character(res$var_info$glycan_composition),
+    as.character(var_info$glycan_composition),
     c("HexNAc(1)dHex(1)", "Hex(5)HexNAc(4)dHex(1)NeuAc(1)")
   )
-  expect_equal(as.numeric(res$expr_mat[, "Sample1"]), c(100, 100))
+  expect_equal(as.numeric(.test_expr_mat(res)[, "Sample1"]), c(100, 100))
 })
 
 test_that("multisite Byonic-pGlycoQuant glycopeptides can be dropped", {
@@ -125,11 +125,14 @@ test_that("multisite Byonic-pGlycoQuant glycopeptides can be dropped", {
     )
   )
 
-  expect_equal(nrow(res$var_info), 1L)
-  expect_equal(res$var_info$peptide_site, 1L)
-  expect_equal(res$var_info$protein_site, 186L)
-  expect_equal(as.character(res$var_info$glycan_composition), "HexNAc(1)")
-  expect_equal(as.numeric(res$expr_mat[, "Sample1"]), 50)
+  expect_equal(nrow(.test_var_info(res)), 1L)
+  expect_equal(.test_var_info(res)$peptide_site, 1L)
+  expect_equal(.test_var_info(res)$protein_site, 186L)
+  expect_equal(
+    as.character(.test_var_info(res)$glycan_composition),
+    "HexNAc(1)"
+  )
+  expect_equal(as.numeric(.test_expr_mat(res)[, "Sample1"]), 50)
 })
 
 test_that("Byonic-pGlycoQuant rows without glycosite markers fail clearly", {
@@ -157,17 +160,17 @@ test_that("peptide_site and protein_site are correctly calculated", {
   )
 
   # Check that peptide_site column exists and contains valid integers
-  expect_true("peptide_site" %in% colnames(res$var_info))
-  expect_type(res$var_info$peptide_site, "integer")
-  expect_true(all(res$var_info$peptide_site > 0))
+  expect_true("peptide_site" %in% colnames(.test_var_info(res)))
+  expect_type(.test_var_info(res)$peptide_site, "integer")
+  expect_true(all(.test_var_info(res)$peptide_site > 0))
 
   # Check that protein_site column exists and contains integers
-  expect_true("protein_site" %in% colnames(res$var_info))
-  expect_type(res$var_info$protein_site, "integer")
-  expect_true(all(res$var_info$protein_site > 0))
+  expect_true("protein_site" %in% colnames(.test_var_info(res)))
+  expect_type(.test_var_info(res)$protein_site, "integer")
+  expect_true(all(.test_var_info(res)$protein_site > 0))
 
   # Check that peptide sequences are properly processed (no modification marks)
-  peptides <- res$var_info$peptide
+  peptides <- .test_var_info(res)$peptide
   expect_true(all(nchar(peptides) > 0))
   expect_false(any(stringr::str_detect(peptides, "\\["))) # No modification brackets
   expect_false(any(stringr::str_detect(peptides, "\\."))) # No prefix/suffix dots
@@ -182,7 +185,7 @@ test_that("protein accessions are correctly extracted", {
   )
 
   # Check protein extraction from UniProt format
-  proteins <- res$var_info$protein
+  proteins <- .test_var_info(res)$protein
   expect_true(all(nchar(proteins) > 0))
 
   # Check some specific examples we know should be in the data
@@ -200,13 +203,13 @@ test_that("glycan compositions are correctly processed and parsed", {
   )
 
   # Check that all glycan compositions are valid glyrepr objects
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
-  expect_true(all(!is.na(res$var_info$glycan_composition)))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
+  expect_true(all(!is.na(.test_var_info(res)$glycan_composition)))
 
   # Check that Fuc has been converted to dHex in the compositions
   # This is verified by checking that the compositions are properly parsed by glyrepr
   # which expects dHex, not Fuc notation
-  compositions_str <- as.character(res$var_info$glycan_composition)
+  compositions_str <- as.character(.test_var_info(res)$glycan_composition)
   expect_true(all(nchar(compositions_str) > 0))
 
   # Verify that standard monosaccharide nomenclature is used
@@ -223,7 +226,7 @@ test_that("variables are correctly named with meaningful IDs", {
     )
   )
 
-  variables <- res$var_info$variable
+  variables <- .test_var_info(res)$variable
   # Variables should be meaningful: protein-site-glycan pattern
   expect_true(all(stringr::str_detect(variables, ".+?-\\d+-.+")))
   # And contain glycan composition info
@@ -241,7 +244,7 @@ test_that("intensity values are correctly processed", {
     )
   )
 
-  expr_mat <- res$expr_mat
+  expr_mat <- .test_expr_mat(res)
 
   # Check that zero values are converted to NA
   expect_true(all(is.na(expr_mat) | expr_mat > 0))
@@ -250,8 +253,8 @@ test_that("intensity values are correctly processed", {
   expect_true(is.numeric(expr_mat))
 
   # Check dimensions
-  expect_equal(nrow(expr_mat), nrow(res$var_info))
-  expect_equal(ncol(expr_mat), nrow(res$sample_info))
+  expect_equal(nrow(expr_mat), nrow(.test_var_info(res)))
+  expect_equal(ncol(expr_mat), nrow(.test_sample_info(res)))
 })
 
 # ----- Sample name extraction -----
@@ -264,8 +267,8 @@ test_that("sample names are correctly extracted from intensity columns", {
   )
 
   # Check that sample name matches the expected pattern
-  expect_equal(res$sample_info$sample, "20241224-lxj-nglyco-h_1")
-  expect_equal(colnames(res$expr_mat), "20241224-lxj-nglyco-h_1")
+  expect_equal(.test_sample_info(res)$sample, "20241224-lxj-nglyco-h_1")
+  expect_equal(colnames(.test_expr_mat(res)), "20241224-lxj-nglyco-h_1")
 })
 
 # ----- Error handling -----
@@ -287,7 +290,7 @@ test_that("it handles O-linked glycan type", {
       glycan_type = "O-GalNAc"
     )
   )
-  expect_equal(res$meta_data$glycan_type, "O-GalNAc")
+  expect_equal(.test_metadata(res)$glycan_type, "O-GalNAc")
 })
 
 # ----- Data consistency -----
@@ -300,18 +303,18 @@ test_that("all output data types are consistent", {
   )
 
   # Check data types of variable information
-  expect_type(res$var_info$peptide, "character")
-  expect_type(res$var_info$protein, "character")
-  expect_type(res$var_info$protein_site, "integer")
-  expect_type(res$var_info$peptide_site, "integer")
+  expect_type(.test_var_info(res)$peptide, "character")
+  expect_type(.test_var_info(res)$protein, "character")
+  expect_type(.test_var_info(res)$protein_site, "integer")
+  expect_type(.test_var_info(res)$peptide_site, "integer")
 
   # Check that all rows have data
-  expect_true(all(nchar(res$var_info$peptide) > 0))
-  expect_true(all(nchar(res$var_info$protein) > 0))
-  expect_true(all(!is.na(res$var_info$protein_site)))
-  expect_true(all(!is.na(res$var_info$peptide_site)))
-  expect_true(all(res$var_info$protein_site > 0))
-  expect_true(all(res$var_info$peptide_site > 0))
+  expect_true(all(nchar(.test_var_info(res)$peptide) > 0))
+  expect_true(all(nchar(.test_var_info(res)$protein) > 0))
+  expect_true(all(!is.na(.test_var_info(res)$protein_site)))
+  expect_true(all(!is.na(.test_var_info(res)$peptide_site)))
+  expect_true(all(.test_var_info(res)$protein_site > 0))
+  expect_true(all(.test_var_info(res)$peptide_site > 0))
 })
 
 # ----- Sample name converter -----
@@ -328,8 +331,8 @@ test_that("sample name converter works", {
     )
   )
 
-  expect_equal(colnames(res$expr_mat), "Sample_1")
-  expect_equal(res$sample_info$sample, "Sample_1")
+  expect_equal(colnames(.test_expr_mat(res)), "Sample_1")
+  expect_equal(.test_sample_info(res)$sample, "Sample_1")
 })
 
 # ----- Parameter validation (minimal, since common validation is tested in pglyco3) -----
@@ -363,5 +366,5 @@ test_that("PSMs are correctly aggregated to glycopeptides", {
     ))
   )
   # Check that aggregation worked correctly
-  expect_equal(nrow(res$var_info), 5)
+  expect_equal(nrow(.test_var_info(res)), 5)
 })

--- a/tests/testthat/test-glycan-finder.R
+++ b/tests/testthat/test-glycan-finder.R
@@ -1,9 +1,9 @@
-test_that("read_glycan_finder() returns a glyexp experiment object", {
+test_that("read_glycan_finder() returns a GlycoproteomicSE object", {
   result <- suppressMessages(read_glycan_finder(
     "data/glycan-finder-result.csv",
     glycan_type = "N"
   ))
-  expect_s3_class(result, "glyexp_experiment")
+  expect_s4_class(result, "GlycoproteomicSE")
 })
 
 test_that(".parse_glycan_finder_peptide() removes modifications", {
@@ -128,7 +128,7 @@ test_that("sample columns exclude summary columns like Area C3 and Area H", {
   ))
 
   # Get sample info and check columns
-  sample_info <- glyexp::get_sample_info(result)
+  sample_info <- .test_sample_info(result)
   sample_names <- sample_info$sample
 
   # Should only have replicate columns (C_3, H_3, H_1, H_2), not summary columns (C3, H)
@@ -152,8 +152,8 @@ test_that("end-to-end with mixed glycan types does not confuse N and O glycans",
     glycan_type = "O-GalNAc"
   ))
 
-  var_info_n <- glyexp::get_var_info(result_n)
-  var_info_o <- glyexp::get_var_info(result_o)
+  var_info_n <- .test_var_info(result_n)
+  var_info_o <- .test_var_info(result_o)
 
   # When reading N-glycans, we should NOT see pure O-glycan compositions
   # (e.g., single HexNAc without Hex)

--- a/tests/testthat/test-glyco-decipher.R
+++ b/tests/testthat/test-glyco-decipher.R
@@ -14,11 +14,11 @@ test_that("it returns correct information (label-free)", {
     "protein_site",
     "glycan_composition"
   )
-  expect_true(all(expected_cols %in% colnames(res$var_info)))
+  expect_true(all(expected_cols %in% colnames(.test_var_info(res))))
 
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
-  expect_type(res$var_info$protein_site, "integer")
-  expect_equal(colnames(res$sample_info), c("sample"))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
+  expect_type(.test_var_info(res)$protein_site, "integer")
+  expect_equal(colnames(.test_sample_info(res)), c("sample"))
 
   # Check sample names and data structure
   expected_samples <- c(
@@ -26,11 +26,11 @@ test_that("it returns correct information (label-free)", {
     "20241224-LXJ-Nglyco-H_2",
     "20241224-LXJ-Nglyco-H_3"
   )
-  expect_true(all(expected_samples %in% colnames(res$expr_mat)))
-  expect_equal(rownames(res$expr_mat), res$var_info$variable)
+  expect_true(all(expected_samples %in% colnames(.test_expr_mat(res))))
+  expect_equal(rownames(.test_expr_mat(res)), .test_var_info(res)$variable)
 
   expect_equal(
-    res$meta_data,
+    .test_metadata(res),
     list(
       exp_type = "glycoproteomics",
       glycan_type = "N",
@@ -50,12 +50,12 @@ test_that("protein inference and site resolution work correctly", {
   )
 
   # Proteins should be properly inferred (no semicolons, proper format)
-  proteins <- res$var_info$protein
+  proteins <- .test_var_info(res)$protein
   expect_false(any(stringr::str_detect(proteins, ";")))
   expect_true(all(stringr::str_detect(proteins, "^[A-Z0-9]+$")))
 
   # Protein sites should be integers, some may be NA for uncertain sites
-  protein_sites <- res$var_info$protein_site
+  protein_sites <- .test_var_info(res)$protein_site
   expect_type(protein_sites, "integer")
   expect_true(any(!is.na(protein_sites))) # Some sites should be determined
 })
@@ -69,7 +69,7 @@ test_that("glycan compositions are correctly processed", {
     )
   )
 
-  compositions <- res$var_info$glycan_composition
+  compositions <- .test_var_info(res)$glycan_composition
   expect_s3_class(compositions, "glyrepr_composition")
 
   # Check that Fuc is converted to dHex and adducts are removed
@@ -89,13 +89,13 @@ test_that("expression matrix and variables are correctly processed", {
   )
 
   # Check expression matrix
-  expect_true(is.numeric(res$expr_mat))
-  expect_equal(nrow(res$expr_mat), nrow(res$var_info))
-  expect_equal(ncol(res$expr_mat), nrow(res$sample_info))
-  expect_true(all(is.na(res$expr_mat) | res$expr_mat > 0))
+  expect_true(is.numeric(.test_expr_mat(res)))
+  expect_equal(nrow(.test_expr_mat(res)), nrow(.test_var_info(res)))
+  expect_equal(ncol(.test_expr_mat(res)), nrow(.test_sample_info(res)))
+  expect_true(all(is.na(.test_expr_mat(res)) | .test_expr_mat(res) > 0))
 
   # Check variable naming
-  variables <- res$var_info$variable
+  variables <- .test_var_info(res)$variable
   # Variables should be meaningful: protein-site-glycan pattern
   # Note: glyco-decipher may have uncertain sites (e.g., "X") so use X instead of N\\d+
   expect_true(all(stringr::str_detect(variables, ".+?-(X|\\d+)-.+")))
@@ -120,8 +120,8 @@ test_that("it handles sample information correctly", {
     "20241224-LXJ-Nglyco-H_2",
     "20241224-LXJ-Nglyco-H_3"
   )
-  expect_true(all(expected_samples %in% res1$sample_info$sample))
-  expect_equal(colnames(res1$sample_info), c("sample"))
+  expect_true(all(expected_samples %in% .test_sample_info(res1)$sample))
+  expect_equal(colnames(.test_sample_info(res1)), c("sample"))
 
   # Custom sample info
   sample_info <- tibble::tibble(
@@ -135,7 +135,7 @@ test_that("it handles sample information correctly", {
       quant_method = "label-free"
     )
   )
-  expect_equal(colnames(res2$sample_info), c("sample", "group"))
+  expect_equal(colnames(.test_sample_info(res2)), c("sample", "group"))
 })
 
 
@@ -167,7 +167,7 @@ test_that("sample name converter works", {
   )
 
   expected_samples <- c("Sample_1", "Sample_2", "Sample_3")
-  expect_true(all(expected_samples %in% colnames(res$expr_mat)))
+  expect_true(all(expected_samples %in% colnames(.test_expr_mat(res))))
 })
 
 
@@ -207,7 +207,7 @@ test_that("it handles different glycan types and orgdb parameters", {
       glycan_type = "O-GalNAc"
     )
   )
-  expect_equal(res1$meta_data$glycan_type, "O-GalNAc")
+  expect_equal(.test_metadata(res1)$glycan_type, "O-GalNAc")
 
   # Custom orgdb (should work even if package not available)
   suppressMessages(
@@ -217,5 +217,5 @@ test_that("it handles different glycan types and orgdb parameters", {
       orgdb = "org.Mm.eg.db"
     )
   )
-  expect_s3_class(res2, "glyexp_experiment")
+  expect_s4_class(res2, "GlycoproteomicSE")
 })

--- a/tests/testthat/test-glyhunter.R
+++ b/tests/testthat/test-glyhunter.R
@@ -4,9 +4,9 @@ test_that("read_glyhunter works", {
     glycan_type = "N"
   ))
 
-  expect_s3_class(exp, "glyexp_experiment")
-  expect_equal(exp$meta_data$exp_type, "glycomics")
-  expect_s3_class(exp$var_info$glycan_composition, "glyrepr_composition")
+  expect_s4_class(exp, "GlycomicSE")
+  expect_equal(.test_metadata(exp)$exp_type, "glycomics")
+  expect_s3_class(.test_var_info(exp)$glycan_composition, "glyrepr_composition")
 })
 
 test_that("read_glyhunter works for NP preset", {
@@ -16,10 +16,10 @@ test_that("read_glyhunter works for NP preset", {
     preset = "Fu_NP_2026"
   ))
 
-  expect_s3_class(exp, "glyexp_experiment")
-  expect_equal(exp$meta_data$exp_type, "glycomics")
-  expect_s3_class(exp$var_info$glycan_composition, "glyrepr_composition")
-  expect_true(all(c("nL", "nE") %in% colnames(exp$var_info)))
+  expect_s4_class(exp, "GlycomicSE")
+  expect_equal(.test_metadata(exp)$exp_type, "glycomics")
+  expect_s3_class(.test_var_info(exp)$glycan_composition, "glyrepr_composition")
+  expect_true(all(c("nL", "nE") %in% colnames(.test_var_info(exp))))
 })
 
 test_that("read_glyhunter works with sample name converter", {
@@ -31,5 +31,5 @@ test_that("read_glyhunter works with sample name converter", {
     }
   ))
 
-  expect_true(all(grepl("^Sample_", colnames(exp$expr_mat))))
+  expect_true(all(grepl("^Sample_", colnames(.test_expr_mat(exp)))))
 })

--- a/tests/testthat/test-msfragger.R
+++ b/tests/testthat/test-msfragger.R
@@ -7,12 +7,12 @@ test_that("it returns correct information (label-free) with single sample", {
     )
   )
 
-  # Check structure of returned experiment object
-  expect_s3_class(res, "glyexp_experiment")
+  # Check structure of returned GlycoproteomicSE object
+  expect_s4_class(res, "GlycoproteomicSE")
 
   # Check variable information columns
   expect_equal(
-    colnames(res$var_info),
+    colnames(.test_var_info(res)),
     c(
       "variable",
       "peptide",
@@ -25,19 +25,19 @@ test_that("it returns correct information (label-free) with single sample", {
   )
 
   # Check glycan composition is properly parsed
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
 
   # Check sample information has correct structure
-  expect_equal(colnames(res$sample_info), "sample")
+  expect_equal(colnames(.test_sample_info(res)), "sample")
 
   # Check expression matrix dimensions and names
-  expect_equal(ncol(res$expr_mat), 3) # Three samples in new test data
-  expect_equal(nrow(res$expr_mat), nrow(res$var_info))
-  expect_equal(rownames(res$expr_mat), res$var_info$variable)
+  expect_equal(ncol(.test_expr_mat(res)), 3) # Three samples in new test data
+  expect_equal(nrow(.test_expr_mat(res)), nrow(.test_var_info(res)))
+  expect_equal(rownames(.test_expr_mat(res)), .test_var_info(res)$variable)
 
   # Check metadata
   expect_equal(
-    res$meta_data,
+    .test_metadata(res),
     list(
       exp_type = "glycoproteomics",
       glycan_type = "N",
@@ -46,8 +46,8 @@ test_that("it returns correct information (label-free) with single sample", {
   )
 
   # Check sample names are extracted correctly from directory structure
-  expect_equal(sort(colnames(res$expr_mat)), c("H_1", "H_2", "H_3"))
-  expect_equal(sort(res$sample_info$sample), c("H_1", "H_2", "H_3"))
+  expect_equal(sort(colnames(.test_expr_mat(res))), c("H_1", "H_2", "H_3"))
+  expect_equal(sort(.test_sample_info(res)$sample), c("H_1", "H_2", "H_3"))
 })
 
 test_that("it provides a default sample information tibble", {
@@ -59,8 +59,8 @@ test_that("it provides a default sample information tibble", {
   )
   # Sample names should be extracted from directory structure
   expected_samples <- c("H_1", "H_2", "H_3")
-  expect_equal(sort(res$sample_info$sample), sort(expected_samples))
-  expect_equal(ncol(res$sample_info), 1)
+  expect_equal(sort(.test_sample_info(res)$sample), sort(expected_samples))
+  expect_equal(ncol(.test_sample_info(res)), 1)
 })
 
 test_that("zeros are replaced by NA", {
@@ -72,7 +72,7 @@ test_that("zeros are replaced by NA", {
   )
   # Check if there are any NA values in the intensity data
   # (should be converted from zero intensities)
-  expect_true(sum(is.na(res$expr_mat)) >= 0)
+  expect_true(sum(is.na(.test_expr_mat(res))) >= 0)
 })
 
 test_that("it filters uncertain or multisite PSMs", {
@@ -84,9 +84,9 @@ test_that("it filters uncertain or multisite PSMs", {
   )
   # All remaining PSMs should have exactly one glycosite
   # This is verified by checking that all variables have valid data
-  expect_true(nrow(res$var_info) > 0)
-  expect_true(all(!is.na(res$var_info$peptide_site)))
-  expect_true(all(!is.na(res$var_info$protein_site)))
+  expect_true(nrow(.test_var_info(res)) > 0)
+  expect_true(all(!is.na(.test_var_info(res)$peptide_site)))
+  expect_true(all(!is.na(.test_var_info(res)$protein_site)))
 })
 
 test_that("it handles O-linked glycan type", {
@@ -97,7 +97,7 @@ test_that("it handles O-linked glycan type", {
       glycan_type = "O-GalNAc"
     )
   )
-  expect_equal(res$meta_data$glycan_type, "O-GalNAc")
+  expect_equal(.test_metadata(res)$glycan_type, "O-GalNAc")
 })
 
 # ----- Parameter validation tests -----
@@ -176,8 +176,8 @@ test_that("sample name converter works", {
     )
   )
   expected_samples <- c("Sample_H_1", "Sample_H_2", "Sample_H_3")
-  expect_equal(sort(colnames(res$expr_mat)), sort(expected_samples))
-  expect_equal(sort(res$sample_info$sample), sort(expected_samples))
+  expect_equal(sort(colnames(.test_expr_mat(res))), sort(expected_samples))
+  expect_equal(sort(.test_sample_info(res)$sample), sort(expected_samples))
 })
 
 # ----- Test glycan composition parsing -----
@@ -190,7 +190,7 @@ test_that("it correctly parses glycan compositions", {
   )
 
   # Check that glycan compositions are properly parsed
-  glycan_comps <- res$var_info$glycan_composition
+  glycan_comps <- .test_var_info(res)$glycan_composition
   expect_true(all(!is.na(glycan_comps)))
 
   # Check that compositions contain expected monosaccharides
@@ -226,10 +226,10 @@ test_that("glycan composition parsing handles complex compositions", {
   )
 
   # Check that all compositions are valid glyrepr objects
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
 
   # Check that compositions have reasonable monosaccharide counts
-  comp_strings <- as.character(res$var_info$glycan_composition)
+  comp_strings <- as.character(.test_var_info(res)$glycan_composition)
   expect_true(all(nchar(comp_strings) > 0))
 
   # Verify that percentage values are stripped (should not contain %)
@@ -245,7 +245,7 @@ test_that("it correctly extracts variable information", {
     )
   )
 
-  var_info <- res$var_info
+  var_info <- .test_var_info(res)
 
   # Check that all required columns are present and of correct type
   expect_true(all(is.character(var_info$variable)))
@@ -280,7 +280,7 @@ test_that("it correctly calculates protein sites from peptide sites", {
     )
   )
 
-  var_info <- res$var_info
+  var_info <- .test_var_info(res)
 
   # Check that protein_site calculation is correct
   # protein_site should be protein_start + peptide_site - 1
@@ -299,7 +299,7 @@ test_that("it handles missing or zero intensity values correctly", {
 
   # Check that zero intensities are converted to NA
   # and that the expression matrix has reasonable values
-  expr_mat <- res$expr_mat
+  expr_mat <- .test_expr_mat(res)
 
   # Should have some non-NA values
   expect_true(sum(!is.na(expr_mat)) > 0)
@@ -355,14 +355,17 @@ test_that("it correctly aggregates PSMs to glycopeptides", {
   )
 
   # Check that aggregation produces reasonable results
-  expect_true(nrow(res$var_info) > 0)
+  expect_true(nrow(.test_var_info(res)) > 0)
 
   # Check that all variables have unique identifiers
-  expect_equal(length(unique(res$var_info$variable)), nrow(res$var_info))
+  expect_equal(
+    length(unique(.test_var_info(res)$variable)),
+    nrow(.test_var_info(res))
+  )
 
   # Check that expression matrix matches variable info
-  expect_equal(nrow(res$expr_mat), nrow(res$var_info))
-  expect_equal(rownames(res$expr_mat), res$var_info$variable)
+  expect_equal(nrow(.test_expr_mat(res)), nrow(.test_var_info(res)))
+  expect_equal(rownames(.test_expr_mat(res)), .test_var_info(res)$variable)
 })
 
 test_that("it preserves sample information structure", {
@@ -382,11 +385,14 @@ test_that("it preserves sample information structure", {
   )
 
   # Check that sample info is preserved correctly
-  expect_equal(nrow(res$sample_info), 3)
-  expect_equal(colnames(res$sample_info), c("sample", "condition", "replicate"))
+  expect_equal(nrow(.test_sample_info(res)), 3)
   expect_equal(
-    res$sample_info$condition,
+    colnames(.test_sample_info(res)),
+    c("sample", "condition", "replicate")
+  )
+  expect_equal(
+    .test_sample_info(res)$condition,
     c("control", "treatment", "treatment")
   )
-  expect_equal(res$sample_info$replicate, c(1, 1, 2))
+  expect_equal(.test_sample_info(res)$replicate, c(1, 1, 2))
 })

--- a/tests/testthat/test-pglyco3-pglycoquant.R
+++ b/tests/testthat/test-pglyco3-pglycoquant.R
@@ -9,7 +9,7 @@ test_that("it returns correct information (label-free)", {
   )
 
   expect_equal(
-    colnames(res$var_info),
+    colnames(.test_var_info(res)),
     c(
       "variable",
       "peptide",
@@ -20,13 +20,13 @@ test_that("it returns correct information (label-free)", {
       "glycan_composition"
     )
   )
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
-  expect_type(res$var_info$protein_site, "integer")
-  expect_equal(colnames(res$sample_info), c("sample", "group"))
-  expect_equal(colnames(res$expr_mat), c("S1", "S2"))
-  expect_equal(rownames(res$expr_mat), res$var_info$variable)
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
+  expect_type(.test_var_info(res)$protein_site, "integer")
+  expect_equal(colnames(.test_sample_info(res)), c("sample", "group"))
+  expect_equal(colnames(.test_expr_mat(res)), c("S1", "S2"))
+  expect_equal(rownames(.test_expr_mat(res)), .test_var_info(res)$variable)
   expect_equal(
-    res$meta_data,
+    .test_metadata(res),
     list(
       exp_type = "glycoproteomics",
       glycan_type = "N",
@@ -47,7 +47,7 @@ test_that("it accepts a sample_info tibble", {
       quant_method = "label-free"
     )
   })
-  expect_equal(colnames(res$sample_info), c("sample", "group"))
+  expect_equal(colnames(.test_sample_info(res)), c("sample", "group"))
 })
 
 
@@ -65,8 +65,8 @@ test_that("it accepts a sample_info data.frame", {
       quant_method = "label-free"
     )
   })
-  expect_equal(colnames(res$sample_info), c("sample", "group"))
-  expect_s3_class(res$sample_info, "tbl_df") # Should be converted to tibble
+  expect_equal(colnames(.test_sample_info(res)), c("sample", "group"))
+  expect_s3_class(.test_sample_info(res), "tbl_df") # Should be converted to tibble
 })
 
 
@@ -77,7 +77,7 @@ test_that("it provides a default sample information tibble (label-free)", {
       quant_method = "label-free"
     )
   )
-  expect_equal(res$sample_info, tibble::tibble(sample = c("S1", "S2")))
+  expect_equal(.test_sample_info(res), tibble::tibble(sample = c("S1", "S2")))
 })
 
 
@@ -104,7 +104,7 @@ test_that("zeros are replaced by NA (label-free)", {
       quant_method = "label-free"
     )
   )
-  expect_true(sum(is.na(res$expr_mat)) > 0)
+  expect_true(sum(is.na(.test_expr_mat(res))) > 0)
 })
 
 
@@ -119,8 +119,8 @@ test_that("sample name converter works", {
       sample_name_converter = sample_name_converter
     )
   )
-  expect_equal(colnames(res$expr_mat), c("Sample_1", "Sample_2"))
-  expect_equal(res$sample_info$sample, c("Sample_1", "Sample_2"))
+  expect_equal(colnames(.test_expr_mat(res)), c("Sample_1", "Sample_2"))
+  expect_equal(.test_sample_info(res)$sample, c("Sample_1", "Sample_2"))
 })
 
 # ----- Parameter validation tests -----
@@ -200,7 +200,7 @@ test_that("it handles O-linked glycan type", {
       glycan_type = "O-GalNAc"
     )
   )
-  expect_equal(res$meta_data$glycan_type, "O-GalNAc")
+  expect_equal(.test_metadata(res)$glycan_type, "O-GalNAc")
 })
 
 # ----- TMT quantification test -----
@@ -224,11 +224,11 @@ test_that("glycan composition parsing works correctly", {
   )
 
   # Check that all glycan compositions are correctly parsed
-  expect_true(all(!is.na(res$var_info$glycan_composition)))
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_true(all(!is.na(.test_var_info(res)$glycan_composition)))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
 
   # Check specific glycan compositions from test data
-  compositions <- res$var_info$glycan_composition
+  compositions <- .test_var_info(res)$glycan_composition
   expect_true(length(compositions) > 0)
 })
 
@@ -242,8 +242,8 @@ test_that("glycan structure parsing works correctly", {
   )
 
   # Check that all glycan structures are parsed
-  expect_s3_class(res$var_info$glycan_structure, "glyrepr_structure")
-  structures <- res$var_info$glycan_structure
+  expect_s3_class(.test_var_info(res)$glycan_structure, "glyrepr_structure")
+  structures <- .test_var_info(res)$glycan_structure
   expect_true(length(structures) > 0)
 })
 
@@ -258,9 +258,9 @@ test_that("parse_structure = TRUE includes glycan_structure column", {
   )
 
   # Check that glycan_structure column exists and is parsed
-  expect_true("glycan_structure" %in% colnames(res$var_info))
-  expect_s3_class(res$var_info$glycan_structure, "glyrepr_structure")
-  expect_true(length(res$var_info$glycan_structure) > 0)
+  expect_true("glycan_structure" %in% colnames(.test_var_info(res)))
+  expect_s3_class(.test_var_info(res)$glycan_structure, "glyrepr_structure")
+  expect_true(length(.test_var_info(res)$glycan_structure) > 0)
 })
 
 
@@ -273,10 +273,10 @@ test_that("parse_structure = FALSE (default) skips glycan structure parsing", {
   )
 
   # Check that glycan_structure column does not exist (default behavior)
-  expect_false("glycan_structure" %in% colnames(res$var_info))
+  expect_false("glycan_structure" %in% colnames(.test_var_info(res)))
   # But glycan_composition should still be parsed
-  expect_true("glycan_composition" %in% colnames(res$var_info))
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_true("glycan_composition" %in% colnames(.test_var_info(res)))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
 })
 
 
@@ -290,10 +290,10 @@ test_that("parse_structure = FALSE explicitly skips glycan structure parsing", {
   )
 
   # Check that glycan_structure column does not exist
-  expect_false("glycan_structure" %in% colnames(res$var_info))
+  expect_false("glycan_structure" %in% colnames(.test_var_info(res)))
   # But glycan_composition should still be parsed
-  expect_true("glycan_composition" %in% colnames(res$var_info))
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_true("glycan_composition" %in% colnames(.test_var_info(res)))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
 })
 
 
@@ -305,7 +305,7 @@ test_that("protein and gene information is correctly processed", {
     )
   )
 
-  genes <- res$var_info$gene
+  genes <- .test_var_info(res)$gene
   # Check that gene names are properly processed (after protein inference)
   expect_true(all(nchar(genes) > 0))
   expect_true(all(!is.na(genes)))
@@ -320,11 +320,11 @@ test_that("expression matrix has correct dimensions and properties", {
     )
   )
 
-  expr_mat <- res$expr_mat
+  expr_mat <- .test_expr_mat(res)
 
   # Check dimensions
-  expect_equal(nrow(expr_mat), nrow(res$var_info))
-  expect_equal(ncol(expr_mat), nrow(res$sample_info))
+  expect_equal(nrow(expr_mat), nrow(.test_var_info(res)))
+  expect_equal(ncol(expr_mat), nrow(.test_sample_info(res)))
 
   # Check that matrix contains numeric values or NA
   expect_true(is.numeric(expr_mat))
@@ -341,7 +341,7 @@ test_that("variable identifiers are unique", {
     )
   )
 
-  variables <- res$var_info$variable
+  variables <- .test_var_info(res)$variable
   expect_equal(length(variables), length(unique(variables)))
   # Variables should be meaningful: protein-site-glycan pattern
   expect_true(all(stringr::str_detect(variables, ".+?-\\d+-.+")))
@@ -381,10 +381,10 @@ test_that("it handles complex sample info with multiple columns", {
   )
 
   expect_equal(
-    colnames(res$sample_info),
+    colnames(.test_sample_info(res)),
     c("sample", "group", "batch", "bio_replicate")
   )
-  expect_equal(res$sample_info$batch, factor(c(1, 2)))
+  expect_equal(.test_sample_info(res)$batch, factor(c(1, 2)))
 })
 
 # ----- Error handling tests -----
@@ -473,14 +473,14 @@ test_that("all output data types are consistent", {
   )
 
   # Check data types of variable information
-  expect_type(res$var_info$peptide, "character")
-  expect_type(res$var_info$protein, "character")
-  expect_type(res$var_info$gene, "character")
-  expect_type(res$var_info$peptide_site, "integer")
-  expect_type(res$var_info$protein_site, "integer")
+  expect_type(.test_var_info(res)$peptide, "character")
+  expect_type(.test_var_info(res)$protein, "character")
+  expect_type(.test_var_info(res)$gene, "character")
+  expect_type(.test_var_info(res)$peptide_site, "integer")
+  expect_type(.test_var_info(res)$protein_site, "integer")
 
   # Check that all rows have data
-  expect_true(all(nchar(res$var_info$peptide) > 0))
+  expect_true(all(nchar(.test_var_info(res)$peptide) > 0))
 })
 
 test_that("intensity columns are correctly extracted", {
@@ -492,7 +492,7 @@ test_that("intensity columns are correctly extracted", {
   )
 
   # Check that intensity column names are correctly processed
-  expr_mat <- res$expr_mat
+  expr_mat <- .test_expr_mat(res)
   expect_true(all(colnames(expr_mat) %in% c("S1", "S2")))
   expect_true(is.numeric(expr_mat))
 
@@ -517,7 +517,7 @@ test_that("PSMs are correctly aggregated to glycopeptides", {
   })
 
   # Check that aggregation worked correctly
-  expect_equal(nrow(res$var_info), nrow(df))
+  expect_equal(nrow(.test_var_info(res)), nrow(df))
 })
 
 # ----- Peptide sequence tests -----
@@ -530,10 +530,10 @@ test_that("J is converted to N in peptide column", {
   )
 
   # J is pGlyco3's notation for glycosylated Asn, should be converted back to N
-  expect_false(any(stringr::str_detect(res$var_info$peptide, "J")))
+  expect_false(any(stringr::str_detect(.test_var_info(res)$peptide, "J")))
 
   # Check that N is present in peptides (since all are N-glycopeptides)
-  expect_true(any(stringr::str_detect(res$var_info$peptide, "N")))
+  expect_true(any(stringr::str_detect(.test_var_info(res)$peptide, "N")))
 
   # Verify no invalid amino acids in peptides (20 standard amino acids)
   valid_aa <- c(
@@ -558,7 +558,7 @@ test_that("J is converted to N in peptide column", {
     "W",
     "Y"
   )
-  all_peptides <- paste(res$var_info$peptide, collapse = "")
+  all_peptides <- paste(.test_var_info(res)$peptide, collapse = "")
   invalid_chars <- stringr::str_remove_all(
     all_peptides,
     paste(valid_aa, collapse = "|")

--- a/tests/testthat/test-pglyco3.R
+++ b/tests/testthat/test-pglyco3.R
@@ -9,7 +9,7 @@ test_that("it returns correct information (label-free)", {
   )
 
   expect_equal(
-    colnames(res$var_info),
+    colnames(.test_var_info(res)),
     c(
       "variable",
       "peptide",
@@ -20,16 +20,16 @@ test_that("it returns correct information (label-free)", {
       "glycan_composition"
     )
   )
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
-  expect_type(res$var_info$protein_site, "integer")
-  expect_equal(colnames(res$sample_info), c("sample", "group"))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
+  expect_type(.test_var_info(res)$protein_site, "integer")
+  expect_equal(colnames(.test_sample_info(res)), c("sample", "group"))
   expect_equal(
-    colnames(res$expr_mat),
+    colnames(.test_expr_mat(res)),
     c("20250315_LiangYuying_GP09_1", "20250315_LiangYuying_GP09_2")
   )
-  expect_equal(rownames(res$expr_mat), res$var_info$variable)
+  expect_equal(rownames(.test_expr_mat(res)), .test_var_info(res)$variable)
   expect_equal(
-    res$meta_data,
+    .test_metadata(res),
     list(
       exp_type = "glycoproteomics",
       glycan_type = "N",
@@ -50,7 +50,7 @@ test_that("it accepts a sample_info tibble", {
       quant_method = "label-free"
     )
   })
-  expect_equal(colnames(res$sample_info), c("sample", "group"))
+  expect_equal(colnames(.test_sample_info(res)), c("sample", "group"))
 })
 
 
@@ -68,7 +68,7 @@ test_that("it accepts a sample_info data.frame", {
       quant_method = "label-free"
     )
   })
-  expect_equal(colnames(res$sample_info), c("sample", "group"))
+  expect_equal(colnames(.test_sample_info(res)), c("sample", "group"))
 })
 
 
@@ -80,7 +80,7 @@ test_that("it provides a default sample information tibble (label-free)", {
     )
   )
   expect_equal(
-    res$sample_info,
+    .test_sample_info(res),
     tibble::tibble(
       sample = c("20250315_LiangYuying_GP09_2", "20250315_LiangYuying_GP09_1")
     )
@@ -112,7 +112,7 @@ test_that("it works with O-glycan type", {
       glycan_type = "O-GalNAc"
     )
   )
-  expect_equal(res$meta_data$glycan_type, "O-GalNAc")
+  expect_equal(.test_metadata(res)$glycan_type, "O-GalNAc")
 })
 
 
@@ -135,8 +135,8 @@ test_that("it works with sample_name_converter", {
     )
   )
 
-  expect_equal(colnames(res$expr_mat), c("Sample_2", "Sample_1"))
-  expect_equal(res$sample_info$sample, c("Sample_2", "Sample_1"))
+  expect_equal(colnames(.test_expr_mat(res)), c("Sample_2", "Sample_1"))
+  expect_equal(.test_sample_info(res)$sample, c("Sample_2", "Sample_1"))
 })
 
 
@@ -203,8 +203,8 @@ test_that("glycan composition parsing works correctly", {
   )
 
   # Check that all glycan compositions are parsed
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
-  compositions <- res$var_info$glycan_composition
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
+  compositions <- .test_var_info(res)$glycan_composition
   expect_true(length(compositions) > 0)
 })
 
@@ -219,8 +219,8 @@ test_that("glycan structure parsing works correctly", {
   )
 
   # Check that all glycan structures are parsed
-  expect_s3_class(res$var_info$glycan_structure, "glyrepr_structure")
-  structures <- res$var_info$glycan_structure
+  expect_s3_class(.test_var_info(res)$glycan_structure, "glyrepr_structure")
+  structures <- .test_var_info(res)$glycan_structure
   expect_true(length(structures) > 0)
 })
 
@@ -235,9 +235,9 @@ test_that("parse_structure = TRUE includes glycan_structure column", {
   )
 
   # Check that glycan_structure column exists and is parsed
-  expect_true("glycan_structure" %in% colnames(res$var_info))
-  expect_s3_class(res$var_info$glycan_structure, "glyrepr_structure")
-  expect_true(length(res$var_info$glycan_structure) > 0)
+  expect_true("glycan_structure" %in% colnames(.test_var_info(res)))
+  expect_s3_class(.test_var_info(res)$glycan_structure, "glyrepr_structure")
+  expect_true(length(.test_var_info(res)$glycan_structure) > 0)
 })
 
 
@@ -250,10 +250,10 @@ test_that("parse_structure = FALSE (default) skips glycan structure parsing", {
   )
 
   # Check that glycan_structure column does not exist (default behavior)
-  expect_false("glycan_structure" %in% colnames(res$var_info))
+  expect_false("glycan_structure" %in% colnames(.test_var_info(res)))
   # But glycan_composition should still be parsed
-  expect_true("glycan_composition" %in% colnames(res$var_info))
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_true("glycan_composition" %in% colnames(.test_var_info(res)))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
 })
 
 
@@ -267,10 +267,10 @@ test_that("parse_structure = FALSE explicitly skips glycan structure parsing", {
   )
 
   # Check that glycan_structure column does not exist
-  expect_false("glycan_structure" %in% colnames(res$var_info))
+  expect_false("glycan_structure" %in% colnames(.test_var_info(res)))
   # But glycan_composition should still be parsed
-  expect_true("glycan_composition" %in% colnames(res$var_info))
-  expect_s3_class(res$var_info$glycan_composition, "glyrepr_composition")
+  expect_true("glycan_composition" %in% colnames(.test_var_info(res)))
+  expect_s3_class(.test_var_info(res)$glycan_composition, "glyrepr_composition")
 })
 
 
@@ -282,7 +282,7 @@ test_that("protein and gene information is correctly processed", {
     )
   )
 
-  genes <- res$var_info$gene
+  genes <- .test_var_info(res)$gene
   # Check that gene names are properly processed (after protein inference)
   expect_true(all(nchar(genes) > 0))
   expect_true(all(!is.na(genes)))
@@ -298,12 +298,12 @@ test_that("expression matrix has correct dimensions and values", {
   )
 
   # Check dimensions
-  expect_equal(nrow(res$expr_mat), nrow(res$var_info))
-  expect_equal(ncol(res$expr_mat), nrow(res$sample_info))
+  expect_equal(nrow(.test_expr_mat(res)), nrow(.test_var_info(res)))
+  expect_equal(ncol(.test_expr_mat(res)), nrow(.test_sample_info(res)))
 
   # Check that values are numeric and non-negative
-  expect_type(res$expr_mat, "double")
-  expect_true(all(res$expr_mat >= 0, na.rm = TRUE))
+  expect_type(.test_expr_mat(res), "double")
+  expect_true(all(.test_expr_mat(res) >= 0, na.rm = TRUE))
 })
 
 
@@ -315,7 +315,7 @@ test_that("variable identifiers are unique", {
     )
   )
 
-  variables <- res$var_info$variable
+  variables <- .test_var_info(res)$variable
   expect_equal(length(variables), length(unique(variables)))
   # Variables should be meaningful: protein-site-glycan pattern
   expect_true(all(stringr::str_detect(variables, ".+?-\\d+-.+")))
@@ -341,7 +341,7 @@ test_that("PSMs are correctly aggregated to glycopeptides", {
 
   # Check that aggregation worked correctly - should have same number of unique glycopeptides
   # The original data has 6 unique glycopeptides after aggregation
-  expect_equal(nrow(res$var_info), 6)
+  expect_equal(nrow(.test_var_info(res)), 6)
 })
 
 # ----- Parse glycan compositions -----
@@ -364,10 +364,10 @@ test_that("J is converted to N in peptide column", {
   )
 
   # J is pGlyco3's notation for glycosylated Asn, should be converted back to N
-  expect_false(any(stringr::str_detect(res$var_info$peptide, "J")))
+  expect_false(any(stringr::str_detect(.test_var_info(res)$peptide, "J")))
 
   # Check that N is present in peptides (since all are N-glycopeptides)
-  expect_true(any(stringr::str_detect(res$var_info$peptide, "N")))
+  expect_true(any(stringr::str_detect(.test_var_info(res)$peptide, "N")))
 
   # Verify no invalid amino acids in peptides (20 standard amino acids)
   valid_aa <- c(
@@ -392,7 +392,7 @@ test_that("J is converted to N in peptide column", {
     "W",
     "Y"
   )
-  all_peptides <- paste(res$var_info$peptide, collapse = "")
+  all_peptides <- paste(.test_var_info(res)$peptide, collapse = "")
   invalid_chars <- stringr::str_remove_all(
     all_peptides,
     paste(valid_aa, collapse = "|")

--- a/tests/testthat/test-sample-info-utils.R
+++ b/tests/testthat/test-sample-info-utils.R
@@ -2,6 +2,9 @@ test_that("numeric and factor sample identifiers are normalized", {
   numeric_info <- tibble::tibble(sample = c(1, 2))
   factor_info <- tibble::tibble(sample = factor(c("1", "2")))
 
+  default_result <- suppressMessages(
+    glyread:::.process_sample_info(NULL, c(1, 2))
+  )
   numeric_result <- glyread:::.process_sample_info(
     numeric_info,
     c("1", "2")
@@ -11,6 +14,7 @@ test_that("numeric and factor sample identifiers are normalized", {
     c("1", "2")
   )
 
+  expect_identical(default_result$sample, c("1", "2"))
   expect_identical(numeric_result$sample, c("1", "2"))
   expect_identical(factor_result$sample, c("1", "2"))
 })

--- a/tests/testthat/test-sample-info-utils.R
+++ b/tests/testthat/test-sample-info-utils.R
@@ -1,0 +1,16 @@
+test_that("numeric and factor sample identifiers are normalized", {
+  numeric_info <- tibble::tibble(sample = c(1, 2))
+  factor_info <- tibble::tibble(sample = factor(c("1", "2")))
+
+  numeric_result <- glyread:::.process_sample_info(
+    numeric_info,
+    c("1", "2")
+  )
+  factor_result <- glyread:::.process_sample_info(
+    factor_info,
+    c("1", "2")
+  )
+
+  expect_identical(numeric_result$sample, c("1", "2"))
+  expect_identical(factor_result$sample, c("1", "2"))
+})

--- a/tests/testthat/test-strucgp.R
+++ b/tests/testthat/test-strucgp.R
@@ -3,8 +3,8 @@ test_that("read_strucgp works", {
     result <- read_strucgp(test_path("data/strucgp-result.xlsx"))
   )
 
-  # Check that result is an experiment object
-  expect_s3_class(result, "glyexp_experiment")
+  # Check that result is a GlycoproteomicSE object
+  expect_s4_class(result, "GlycoproteomicSE")
 
   # Check var_info has expected columns (peptide is removed after standardization)
   expected_cols <- c(
@@ -15,33 +15,36 @@ test_that("read_strucgp works", {
     "glycan_composition",
     "glycan_structure"
   )
-  expect_true(all(expected_cols %in% colnames(result$var_info)))
+  expect_true(all(expected_cols %in% colnames(.test_var_info(result))))
 
   # Check column types in var_info
-  expect_type(result$var_info$variable, "character")
-  expect_type(result$var_info$protein, "character")
-  expect_type(result$var_info$gene, "character")
-  expect_type(result$var_info$protein_site, "integer")
-  expect_s3_class(result$var_info$glycan_composition, "glyrepr_composition")
-  expect_s3_class(result$var_info$glycan_structure, "glyrepr_structure")
+  expect_type(.test_var_info(result)$variable, "character")
+  expect_type(.test_var_info(result)$protein, "character")
+  expect_type(.test_var_info(result)$gene, "character")
+  expect_type(.test_var_info(result)$protein_site, "integer")
+  expect_s3_class(
+    .test_var_info(result)$glycan_composition,
+    "glyrepr_composition"
+  )
+  expect_s3_class(.test_var_info(result)$glycan_structure, "glyrepr_structure")
 
   # Check that var_info has data
-  expect_gt(nrow(result$var_info), 0)
+  expect_gt(nrow(.test_var_info(result)), 0)
 
   # Check that expr_mat is a binary (0/1) matrix
-  expect_true(all(result$expr_mat %in% c(0, 1)))
-  expect_equal(nrow(result$expr_mat), nrow(result$var_info))
+  expect_true(all(.test_expr_mat(result) %in% c(0, 1)))
+  expect_equal(nrow(.test_expr_mat(result)), nrow(.test_var_info(result)))
 
   # Check that at least some glycopeptides were identified (have 1s)
-  expect_true(any(result$expr_mat == 1))
+  expect_true(any(.test_expr_mat(result) == 1))
 
   # Check that sample_info exists
-  expect_s3_class(result$sample_info, "tbl_df")
-  expect_true("sample" %in% colnames(result$sample_info))
-  expect_gt(nrow(result$sample_info), 0)
+  expect_s3_class(.test_sample_info(result), "tbl_df")
+  expect_true("sample" %in% colnames(.test_sample_info(result)))
+  expect_gt(nrow(.test_sample_info(result)), 0)
 
   # Check dimensions match
-  expect_equal(ncol(result$expr_mat), nrow(result$sample_info))
+  expect_equal(ncol(.test_expr_mat(result)), nrow(.test_sample_info(result)))
 })
 
 test_that("read_strucgp works with parse_structure = FALSE", {
@@ -52,15 +55,18 @@ test_that("read_strucgp works with parse_structure = FALSE", {
     )
   )
 
-  # Check that result is an experiment object
-  expect_s3_class(result, "glyexp_experiment")
+  # Check that result is a GlycoproteomicSE object
+  expect_s4_class(result, "GlycoproteomicSE")
 
   # Check var_info does NOT have glycan_structure column
-  expect_false("glycan_structure" %in% colnames(result$var_info))
+  expect_false("glycan_structure" %in% colnames(.test_var_info(result)))
 
   # Check that glycan_composition is still present
-  expect_true("glycan_composition" %in% colnames(result$var_info))
-  expect_s3_class(result$var_info$glycan_composition, "glyrepr_composition")
+  expect_true("glycan_composition" %in% colnames(.test_var_info(result)))
+  expect_s3_class(
+    .test_var_info(result)$glycan_composition,
+    "glyrepr_composition"
+  )
 })
 
 test_that("read_strucgp works with custom sample_info", {
@@ -78,8 +84,8 @@ test_that("read_strucgp works with custom sample_info", {
   )
 
   # Check that sample_info is included
-  expect_true("group" %in% colnames(result$sample_info))
-  expect_equal(as.character(result$sample_info$group), c("treatment"))
+  expect_true("group" %in% colnames(.test_sample_info(result)))
+  expect_equal(as.character(.test_sample_info(result)$group), c("treatment"))
 })
 
 test_that(".parse_strucgp_comp works correctly", {

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -1,0 +1,23 @@
+test_that("all-missing abundance does not warn", {
+  tidy_df <- tibble::tibble(
+    sample = "S1",
+    value = 0,
+    protein = "P1",
+    protein_site = 1L,
+    glycan_composition = "Hex(1)"
+  )
+
+  expect_no_warning(
+    result <- suppressMessages(glyread:::.read_template(
+      tidy_df,
+      sample_info_arg = NULL,
+      glycan_type = "N",
+      quant_method = "label-free",
+      composition_parser = glyrepr::as_glycan_composition,
+      parse_structure = FALSE
+    ))
+  )
+
+  expect_s4_class(result, "GlycoproteomicSE")
+  expect_true(all(is.na(SummarizedExperiment::assay(result, "abundance"))))
+})

--- a/vignettes/glyread.Rmd
+++ b/vignettes/glyread.Rmd
@@ -14,8 +14,8 @@ knitr::opts_chunk$set(
 )
 ```
 
-Glycomics and glycoproteomics data find their home in `experiment()` objects from [glyexp](https://github.com/glycoverse/glyexp)—a tidy, structured format designed specifically for glycobiology workflows.
-Working with glycopeptide identification tools like `pGlyco3` or `MSFragger-Glyco`? You can seamlessly import your results into `experiment()` objects with just a few lines of code using `glyread`.
+Glycomics and glycoproteomics data find their home in `GlycomicSE` and `GlycoproteomicSE` objects from [glyexp](https://github.com/glycoverse/glyexp)—a tidy, structured format designed specifically for glycobiology workflows.
+Working with glycopeptide identification tools like `pGlyco3` or `MSFragger-Glyco`? You can seamlessly import your results into `GlycomicSE` and `GlycoproteomicSE` objects with just a few lines of code using `glyread`.
 
 ## One function, two files — that's it
 
@@ -48,10 +48,10 @@ Pro tip: Quality control samples should be labeled "QC" in the `group` column �
 With your files ready, importing data is a one-liner. Here's a practical example: suppose you used pGlyco3 for identification and pGlycoQuant for quantification, with results in `pglyco3_result.csv` and sample details in `samples.csv`:
 
 ```r
-exp <- read_pglyco3_pglycoquant("pglyco3_result.csv", sample_info = "samples.csv")
+se <- read_pglyco3_pglycoquant("pglyco3_result.csv", sample_info = "samples.csv")
 ```
 
-That's it — your data is now ready for analysis in a tidy `experiment()` object.
+That's it — your data is now ready for analysis in a `GlycoproteomicSE` object.
 
 ## What's next?
 


### PR DESCRIPTION
## Summary

Migrate every `glyread` importer to return the new SummarizedExperiment-based glyco containers.

- `read_glyhunter()` now returns `glyexp::GlycomicSE`.
- All glycoproteomics readers now return `glyexp::GlycoproteomicSE`.
- Legacy `glyexp::experiment()` construction and field access are removed from `glyread`.

## Background

This is the `glyread` migration step in Stage II of [glycoverse/glyexp#15](https://github.com/glycoverse/glyexp/issues/15), which makes the new SummarizedExperiment subclasses the recommended data containers.

## Rational

Returning the typed SE subclasses directly gives downstream Bioconductor-compatible assay, `rowData`, `colData`, and metadata contracts. This is a breaking return-type change: callers using `$expr_mat`, `$var_info`, `$sample_info`, or `$meta_data` must migrate to the corresponding SummarizedExperiment accessors.

## Details

- Add native constructors that align assay dimnames with sample and variable metadata.
- Preserve meaningful standardized glycoproteomics variable identifiers.
- Preserve experiment type, glycan type, and quantification method metadata.
- Normalize numeric and factor sample identifiers to character dimnames.
- Handle valid all-missing abundance assays without leaking the upstream empty-`min()` warning.
- Update tests, package dependencies, function documentation, README, vignette, and NEWS for the new return types.

## Verification

- `devtools::document()`
- Focused regression tests for sample identifier normalization and all-missing assays: 5 passed
- Full `devtools::test()`: passed
- `devtools::check(args = "--no-manual", error_on = "warning")`: 0 errors, 0 warnings, 0 notes
- `git diff --check`: passed

Part of glycoverse/glyexp#15.