### PR TITLE
Require glyexp 0.16.0 for Stage II migration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     cli,
     dplyr,
     fs,
-    glyexp (>= 0.15.0),
+    glyexp (>= 0.16.0),
     glyparse (>= 0.5.3),
     glyrepr (>= 0.7.4),
     janitor,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glyread (development version)
 
+* The minimum `glyexp` version is now 0.16.0 for the Stage II container migration in glycoverse/glyexp#15.
+
 # glyread 0.12.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyread (development version)
 
-* The minimum `glyexp` version is now 0.16.0 for the Stage II container migration in glycoverse/glyexp#15.
+* The minimum `glyexp` version is now 0.16.0 for the Stage II container migration in glycoverse/glyexp#15. (#15)
 
 # glyread 0.12.0
 


### PR DESCRIPTION
Part of glycoverse/glyexp#15.

## Summary
- Raise the minimum `glyexp` version to 0.16.0 so `glyread` installs with the Stage II container release.
- Keep the existing `GlycomicSE` and `GlycoproteomicSE` reader outputs unchanged.

## Verification
- `devtools::check()` — 0 errors, 0 warnings, 0 notes.